### PR TITLE
Corrections to IHO S-98

### DIFF
--- a/collection.yml
+++ b/collection.yml
@@ -1,0 +1,51 @@
+---
+directives:
+  - documents-inline
+  - recompile-xml: true
+  #- coverpage: index.html
+
+output_folder: collection
+
+bibdata:
+  title:
+    type: title-main
+    language: en
+    content: IHO S-98 Interoperability Specification for S-100 Navigation Systems
+
+  type: collection
+
+  docid:
+    type: iho
+    id: IHO S-98
+
+  edition: "2.0.0"
+
+  date:
+    - type: created
+      value: "2025-03-01"
+
+  copyright:
+    owner:
+      name: International Hydrographic Organization
+      abbreviation: IHO
+    from: "2025"
+
+format:
+  - xml
+  - html
+  - presentation
+  - doc
+  - pdf
+
+manifest:
+  docref:
+    - file: sources/2.0.0/main/document.adoc
+      identifier: IHO S-98
+    - file: sources/2.0.0/part-a/document.adoc
+      identifier: IHO S-98 Part A
+    - file: sources/2.0.0/part-b/document.adoc
+      identifier: IHO S-98 Part B
+    - file: sources/2.0.0/part-c/document.adoc
+      identifier: IHO S-98 Part C
+    - file: sources/2.0.0/part-d/document.adoc
+      identifier: IHO S-98 Part D

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -7,6 +7,7 @@ metanorma:
       - sources/2.0.0/part-b/document.adoc
       - sources/2.0.0/part-c/document.adoc
       - sources/2.0.0/part-d/document.adoc
+      - sources/2.0.0/main/document.adoc
 
   collection:
     organization: "IHO: International Hydrographic Organization"

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -7,7 +7,6 @@ metanorma:
       - sources/2.0.0/part-b/document.adoc
       - sources/2.0.0/part-c/document.adoc
       - sources/2.0.0/part-d/document.adoc
-      - sources/2.0.0/main/document.adoc
 
   collection:
     organization: "IHO: International Hydrographic Organization"

--- a/sources/2.0.0/main/sections/00-preface.adoc
+++ b/sources/2.0.0/main/sections/00-preface.adoc
@@ -1,73 +1,119 @@
 [.preface]
-== Document History
+== metanorma-extension
 
+[.boilerplate]
+--
 Changes to this Specification are coordinated by the IHO S-100 Working
 Group. New editions will be made available via the IHO website. Maintenance
 of the Specification shall conform to IHO Resolution 2/2007 (as amended).
+--
 
-[cols="87,93,69,299"]
-|===
-h| Version Number h| Date h| Approved By h| Purpose
+=== document history
 
-| 0.0.1 | 28 Aug 2020 | RM       | First draft. Reviewed by EM.
-| 0.0.2 | 01 Nov 2021 | J.Powell | Numerous revisions to take into account the S-98 Correspondence Group adjudication work.
-| 1.0.0 | May 2022    | S-100WG  | Submission to HSSC14 for approval.
-| 1.0.0 | May 2022    | HSSC     | Initial published version for evaluation and testing.
-
-| 1.1.0
-| August 2023
-|
-| Added MSC.530(106)/Rev.1 in place of MSC.232(82) and updated text
-accordingly ("SENC" to "System Database"- various clauses); updated
-tidal stream panel presentation (C-15.4); fixed heading 1 and heading
-2 styles; added new clause listing allowed support file formats for
-ECDIS and elaborated rules for additional information in text (C-11.5);
-struck alternate labels in Tables C-2 and C-3;
-
-| 1.2.0
-| February 2024
-|
-| Collection of issues identified by subgroup and external stakeholder.
-
-| 1.3.0
-| May 2024
-|
-| Incorporating stakeholder inputs, GitHub discussions and TSM 2024 outputs.
-
-| 1.3.4
-| July 2024
-|
-| Version after review meetings
-
-| 1.4.0
-| August 2024
-|
-| Version prepared for F2F meeting with stakeholders.
-
-| 1,6.0
-| September 2024
-|
-| Prepared following Face to Face meeting.
-
-| 1.7.1
-| October 2024
-|
-| Remainder of comments received applied and commented.
-
-| 1.8.0 [2.0.0]
-| January 2025
-|
-| Draft for 2.0.0, HSSC 2025 following VTC reviews and resolutions
-of comments from F2F meeting.
-
-| 1.9.0[2.0.0]
-| March 2025
-|
-| Prepared version for TSM 2025
-
-| 2.0.0
-| March 2025
-|
-| Version submitted to HSSC 2025
-
-|===
+[source,yaml]
+----
+- date:
+  - type: published
+    value: 2020-08-28
+  edition: "0.0.1"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: First draft. Reviewed by EM.
+- date:
+  - type: updated
+    value: 2021-11-01
+  edition: "0.0.2"
+  contributor:
+  - person:
+      name:
+        completename: J. Powell
+        abbreviation: JP
+  amend:
+    - description: Numerous revisions to take into account the S-98 Correspondence Group adjudication work.
+- date:
+  - type: updated
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: S-100 Working Group
+      abbreviation: S-100WG
+  amend:
+    - description: Submission to HSSC14 for approval.
+- date:
+  - type: published
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: IHO Hydrographic Services and Standards Committee
+      abbreviation: HSSC
+  amend:
+   - description: Initial published version for evaluation and testing.
+- date:
+  - type: updated
+    value: 2023-08
+  edition: "1.1.0"
+  amend:
+   - description: Added MSC.530(106)/Rev.1 in place of MSC.232(82) and updated text accordingly ("SENC" to "System Database"- various clauses); updated tidal stream panel presentation (C-15.4); fixed heading 1 and heading 2 styles; added new clause listing allowed support file formats for ECDIS and elaborated rules for additional information in text (C-11.5); struck alternate labels in Tables C-2 and C-3;
+- date:
+  - type: updated
+    value: 2024-02
+  edition: "1.2.0"
+  amend:
+   - description: Collection of issues identified by subgroup and external stakeholder.
+- date:
+  - type: updated
+    value: 2024-05
+  edition: "1.3.0"
+  amend:
+   - description: Incorporating stakeholder inputs, GitHub discussions and TSM 2024 outputs.
+- date:
+  - type: updated
+    value: 2024-07
+  edition: "1.3.4"
+  amend:
+   - description: Version after review meetings
+- date:
+  - type: updated
+    value: 2024-08
+  edition: "1.4.0"
+  amend:
+   - description: Version prepared for F2F meeting with stakeholders.
+- date:
+  - type: updated
+    value: 2024-09
+  edition: "1.6.0"
+  amend:
+   - description: Prepared following Face to Face meeting.
+- date:
+  - type: updated
+    value: 2024-10
+  edition: "1.7.1"
+  amend:
+   - description: Remainder of comments received applied and commented.
+- date:
+  - type: updated
+    value: 2025-01
+  edition: "1.8.0 [2.0.0]"
+  amend:
+   - description: Draft for 2.0.0, HSSC 2025 following VTC reviews and resolutions of comments from F2F meeting.
+- date:
+  - type: updated
+    value: 2025-03
+  edition: "1.9.0 [2.0.0]"
+  amend:
+   - description: Prepared version for TSM 2025
+- date:
+  - type: updated
+    value: 2025-03
+  edition: "2.0.0"
+  amend:
+   - description: Version submitted to HSSC 2025
+----

--- a/sources/2.0.0/main/sections/01-introduction.adoc
+++ b/sources/2.0.0/main/sections/01-introduction.adoc
@@ -7,8 +7,8 @@ Electronic Navigational Chart (ENC) and other S-100 based data products
 in an Electronic Chart Display and Information System (ECDIS). It
 describes how S-100 products are to be used and displayed simultaneously
 on the navigation screen. It does not address the portrayal processes
-or architectures, which are addressed in S-100 Part 9. It is based
-on the general principles described in S-100 Part 16A, and the requirements
+or architectures, which are addressed in <<IHO_S_100,part=9>>. It is based
+on the general principles described in <<IHO_S_100,part=16a>>, and the requirements
 for ECDIS specified in the relevant International Maritime Organization
 (IMO), International Hydrographic Organization (IHO), and International
 Electrotechnical Commission (IEC) standards.
@@ -53,7 +53,7 @@ water levels, regulated areas, services and weather.
 
 The standards that are current at the time of writing of this specification
 are listed in the References section. More detailed information about
-the various standards is provided in S-100 Part 16a.
+the various standards is provided in <<IHO_S_100,part=16a>>.
 
 Application developers should obtain an up-to-date set of applicable
 standards and specifications from the relevant organisations. Developers
@@ -89,7 +89,7 @@ simultaneously.
 for development of Interoperability Catalogues that can be used by
 systems to control the simultaneous use and display of two or more
 S-100 based data products. It is an implementation of the abstract
-interoperability concepts described in S-100 Part 16. Part A and B
+interoperability concepts described in <<IHO_S_100,part=16>>. Part A and B
 of this specification define levels 1 and 2 respectively.
 
 NOTE: the current edition of S-98 does not use the full interoperability

--- a/sources/2.0.0/main/sections/01-introduction.adoc
+++ b/sources/2.0.0/main/sections/01-introduction.adoc
@@ -89,7 +89,7 @@ simultaneously.
 for development of Interoperability Catalogues that can be used by
 systems to control the simultaneous use and display of two or more
 S-100 based data products. It is an implementation of the abstract
-interoperability concepts described in <<IHO_S_100,part=16>>. Part A and B
+interoperability concepts described in <<IHO_S_100,part=16>>. <<PartA;and!PartB>>
 of this specification define levels 1 and 2 respectively.
 
 NOTE: the current edition of S-98 does not use the full interoperability

--- a/sources/2.0.0/main/sections/02-references.adoc
+++ b/sources/2.0.0/main/sections/02-references.adoc
@@ -44,3 +44,13 @@ All references refer to the latest revision or amendment.
 * [[[IHO_S_4,IHO S-4]]]
 
 * [[[IHO_S_52,IHO S-52]]]
+
+* [[[PartA,dropid(repo:(current-metanorma-collection/IHO S-98 Part A))]]],
+span:title[S-98 - Part A: Level 1 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartB,dropid(repo:(current-metanorma-collection/IHO S-98 Part B))]]],
+span:title[S-98 - Part B: Level 2 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]

--- a/sources/2.0.0/main/sections/02-references.adoc
+++ b/sources/2.0.0/main/sections/02-references.adoc
@@ -1,40 +1,42 @@
 == References
 
-[bibliography]
+[bibliography,normative=true]
 === Normative references
 
 * [[[ref1,A.1021(26)]]]
-span:title[_Code on Alerts and Indicators (2009)_], span:date[2009], span:publisher[IMO Resolution A.1021(26)]
+_span:title[Code on Alerts and Indicators (2009)]_, span:date[2009], span:publisher[IMO Resolution A.1021(26)]
 
 * [[[IEC_60945,IEC 60945]]]
 
-* [[IEC_61174,IEC 61174]]
+* [[[IEC_61174,IEC 61174]]]
 
 * [[[IEC_62288,IEC 62288]]]
 
 * [[[IEC_63173_2,IEC 63173-2]]]
 
-* [[[ref5,5]]] MSC.191(79) _Amendments to the Performance Standards for the Presentation of Navigation-Related Information on Shipborne Navigational Displays_, IMO Resolution MSC.191(79), 2004. As amended by MSC 466(101).
+* [[[IEC_63173_1,hidden(IEC 63173-1)]]]
 
-* [[[ref6,6]]] MSC.252(83) _Performance Standards for Integrated Navigation Systems (INS)_, IMO Resolution 252(83), 2007.
+* [[[ref5,MSC.191(79)]]] MSC.191(79) _Amendments to the Performance Standards for the Presentation of Navigation-Related Information on Shipborne Navigational Displays_, IMO Resolution MSC.191(79), 2004. As amended by MSC 466(101).
 
-* [[[ref7,7]]] MSC.302(87) _Adoption of Performance Standards for Bridge Alert Management_, IMO Resolution 302(87), 2010.
+* [[[ref6,MSC.252(83)]]] MSC.252(83) _Performance Standards for Integrated Navigation Systems (INS)_, IMO Resolution 252(83), 2007.
 
-* [[[ref8,8]]] MSC.466(101) _Amendments to the Performance Standards for the Presentation of Navigation-Related Information on Shipborne Navigational Displays_, Resolution MSC.191(79), 2019.
+* [[[ref7,MSC.302(87)]]] MSC.302(87) _Adoption of Performance Standards for Bridge Alert Management_, IMO Resolution 302(87), 2010.
 
-* [[[ref9,9]]] MSC.530(106)/Rev. 1 Performance Standards for Electronic Chart Display and Information Systems (ECDIS), Resolution MSC.530(106)/Rev.1, 2024.
+* [[[ref8,MSC.466(101)]]] MSC.466(101) _Amendments to the Performance Standards for the Presentation of Navigation-Related Information on Shipborne Navigational Displays_, Resolution MSC.191(79), 2019.
 
-* [[[ref10,10]]] MSC.1/Circ.1609 _Guidelines for the Standardization of User Interface Design for Navigation Equipment_, IMO MSC.1/Circ 1609, 2019.
+* [[[ref9,MSC.530(106)/Rev.1]]] MSC.530(106)/Rev.1 Performance Standards for Electronic Chart Display and Information Systems (ECDIS), Resolution MSC.530(106)/Rev.1, 2024.
+
+* [[[ref10,MSC.1/Circ.1609]]] MSC.1/Circ.1609 _Guidelines for the Standardization of User Interface Design for Navigation Equipment_, IMO MSC.1/Circ 1609, 2019.
 
 * [[[IHO_S_97,IHO S-97]]]
 
 * [[[IHO_S_100,IHO S-100]]]
 
-* [[[ref13,13]]] SN.1/Circ.243/Rev. 2 _Guidelines for the Presentation of Navigational-Related Symbols, Terms and Abbreviations_, IMO SN.1/Circ.243/Rev.2, 2019.
+* [[[ref13,SN.1/Circ.243/Rev.2]]] SN.1/Circ.243/Rev.2 _Guidelines for the Presentation of Navigational-Related Symbols, Terms and Abbreviations_, IMO SN.1/Circ.243/Rev.2, 2019.
 
 All references refer to the latest revision or amendment.
 
-[bibliography]
+[bibliography,normative=false]
 === Informative references
 
 * [[[ISO_19117,ISO 19117]]]

--- a/sources/2.0.0/main/sections/04-background.adoc
+++ b/sources/2.0.0/main/sections/04-background.adoc
@@ -8,7 +8,7 @@ include multiple products for use in navigation systems. They were
 introduced in IMO MSC 530(106) and update the previous concept of
 SENC defined in IMO MSC.232(82).
 
-IMO MSC.530(106)/Rev.1 defines Electronic Navigational Chart (ENC),
+<<ref9>> defines Electronic Navigational Chart (ENC),
 Electronic Navigational Data Service (ENDS), and System Database as
 follows:
 
@@ -43,7 +43,7 @@ and/or S-57 based products.
 [[sec_4.2]]
 === ECDIS concept, limitations, and challenges
 
-IMO MSC 530(106)/Rev.1 also defines Electronic Chart Display and Information
+<<ref9>> also defines Electronic Chart Display and Information
 System (ECDIS):
 
 ____
@@ -176,7 +176,7 @@ of this document.
 === Integrated Navigation System (INS) concept, limitations and challenges
 
 The concept of an Integrated Navigation System (INS) is outlined in
-the IMO Performance Standards MSC 252(83). INS workstations have multifunctional
+the IMO Performance Standards <<ref6>>. INS workstations have multifunctional
 displays providing at least route monitoring and collision avoidance
 functions, and may provide manual or automatic navigation control
 functions. In addition to these functions, an INS generally also provide

--- a/sources/2.0.0/main/sections/05-user-interface.adoc
+++ b/sources/2.0.0/main/sections/05-user-interface.adoc
@@ -3,8 +3,8 @@
 
 === General principles
 
-The guidelines in IMO MSC.1/Circ.1609 (Guidelines for the Standardization
+The guidelines in <<ref10>> (Guidelines for the Standardization
 of User Interface Design for Navigational Equipment) apply to the
 design of user interfaces for navigation systems such as ECDIS and
-INS. The general principles are described in MSC.1/Circ.1609 and are
-summarised in S-100 Part 16A.
+INS. The general principles are described in <<ref10>> and are
+summarised in <<IHO_S_100,part=16a>>.

--- a/sources/2.0.0/main/sections/06-data-layers.adoc
+++ b/sources/2.0.0/main/sections/06-data-layers.adoc
@@ -58,7 +58,7 @@ data products
 To prevent the simultaneous presentation of multiple data layers from
 cluttering the presentation and hiding critical information, the ECDIS
 shall implement good practice in user interface design, including
-the applicable IMO requirements (MSC.191(79), MSC.1/Circ1609),
+the applicable IMO requirements (<<ref5>>, <<ref10>>),
 see also <<sec_8>>.
 
 Detection of and response to possible data overload should be guided

--- a/sources/2.0.0/main/sections/07-portrayal.adoc
+++ b/sources/2.0.0/main/sections/07-portrayal.adoc
@@ -4,8 +4,8 @@
 This section provides a brief, informative summary of the S-100 portrayal
 process, the main elements of Portrayal Catalogues, and the alert
 model. More details about the process and definitions of Portrayal
-Catalogue elements and the alerting model are available in S-100 Parts
-9 and 9a.
+Catalogue elements and the alerting model are available in
+<<IHO_S_100,part=9>> and <<IHO_S_100,part=9a>>.
 
 Later sections of this document describe how the portrayal elements
 should be used in an ECDIS implementation.
@@ -25,21 +25,22 @@ produce the final display according to the output device.
 
 S-100 describes two different portrayal mechanisms, one based on XSLT
 templates and the other based on the scripting capability described
-in S-100 Part 13. The basic portrayal process is the same for both,
-and is described in S-100 Part 9 and 9a.
+in <<IHO_S_100,part=13>>. The basic portrayal process is the same for both,
+and is described in <<IHO_S_100,part=9>> and <<IHO_S_100,part=9a>>.
 
 When interoperability is activated and there is an interoperable product
 loaded to the display, either feature data or drawing instructions
 (depending on the implementation architecture) are further filtered
 and/or have their priorities adjusted as specified in the interoperability
-catalogue. Interoperability processing is described in S-100 Part
-16 and in Annexes A and B of this specification (Note that such interoperability
+catalogue. Interoperability processing is described in <<IHO_S_100,part=16>>
+and in <<IHO_S_100,annex=A>> and <<IHO_S_100,annex=B>> of this specification
+(Note that such interoperability
 is not operational in this edition of S-98).
 
 === Elements of S-100 Portrayal
 
 Much of the content of this section is included for information as
-it is described definitively in S-100 Part 9 and Part 9a.
+it is described definitively in <<IHO_S_100,part=9>> and <<IHO_S_100,part=9a>>.
 
 ==== Pixmaps
 
@@ -97,9 +98,9 @@ composed of repeating line patterns.
 Simple line styles are generally described by continuity, width, and
 colour. The full specification of a simple line style may also include
 other elements such as dash interval, cap and join types
-(see S-100 clauses 9-12.4 and 9a-11.2.2.3), defaults for which may
+(see <<IHO_S_100,clause="9-12.4">> and <<IHO_S_100,clause="9a-11.2.2.3">>), defaults for which may
 be set in the Portrayal Catalogue. Complex line styles consist of
-additional elements, described in S-100 9-12.4 and 9a-11.2.2.3.
+additional elements, described in <<IHO_S_100,clause="9-12.4">> and <<IHO_S_100,clause="9a-11.2.2.3">>.
 
 Complex linestyles may be one-sided (symbols, text, etc., which are
 part of the line extend to only one side of the line) or two-sided
@@ -156,7 +157,7 @@ locations.
 However, explicit cartographic placement along curves or relative
 to area/local CRS cannot be explicitly encoded in S-101 datasets,
 though it can be encoded in portrayal rules in a Portrayal Catalogue
-(S-100 Part 9a, clause 9a-11.2).
+(<<IHO_S_100,clause="9a-11.2">>).
 
 ==== Style sheets
 
@@ -166,7 +167,7 @@ This mechanism allows changing colours and line weights used in the
 symbols by swapping CSS files according to the desired colour scheme.
 
 In principle, any style attribute can be set in a CSS file, but the
-CSS files in IHO Portrayal Catalogues are restricted by S-100 9-B-4.4
+CSS files in IHO Portrayal Catalogues are restricted by <<IHO_S_100,clause="9b-4.4">>
 to only two use cases: setting stroke and fill colours, altering the
 visibility of elements which are not normally displayed
 (for example, the pivot point).
@@ -180,8 +181,8 @@ drawn over a radar image.
 
 ==== Display (drawing) priorities
 
-Display priorities are also called "drawing priorities" in S-100 Parts
-9 and 9a.
+Display priorities are also called "drawing priorities" in
+<<IHO_S_100,part=9>> and <<IHO_S_100,part=9a>>.
 
 Display priorities control the order in which the output of the portrayal
 functions is processed by the rendering engine within a display plane.
@@ -237,10 +238,10 @@ of the smallest granularity. For example, if the end instant is specified
 a date without a time of day, and the interval is "right-closed",
 the end instant is midnight at the end of the specified day
 (240000 in ISO 8601 terms). This is consistent with the S-100 treatment
-of _dateStart_ and _dateEnd_ attributes (see S-100 Part 3 clause 3-8-3
+of _dateStart_ and _dateEnd_ attributes (see <<IHO_S_100,clause="3-8-3">>
 (Interpretation of models of time intervals and period), but note
 that the open/closed nature of the interval affects the interpretation
-for Part 9 time intervals — if the same interval is specified as "right-open"
+for Part 9 time intervals -- if the same interval is specified as "right-open"
 the start time point is midnight at the beginning of the specified
 day (000000 in ISO 8601 terms).
 
@@ -259,4 +260,4 @@ and are triggered when the vessel route (either actual track, during
 route monitoring, or planned, during route planning) intersects the
 geometry (which may be restricted or augmented) of a feature.
 The events are alarms, alerts, warnings, cautions, or indications
-as described in IMO MSC.252(83).
+as described in <<ref6>>.

--- a/sources/2.0.0/main/sections/09-display.adoc
+++ b/sources/2.0.0/main/sections/09-display.adoc
@@ -11,7 +11,7 @@ official S-100-based data products, S-57, radar, or AIS.
 [[sec_9.1.1]]
 ==== Distinguishing between official S-100 data and additional data
 
-IMO Performance Standards (MSC.530(106)/Rev.1 section 1.5) states
+IMO Performance Standards (<<ref9,section="1.5">>) states
 that ECDIS should enable the mariner to execute all route planning,
 route monitoring, and positioning and sections 3.3-3.4 mean that the
 ENDS and System Database may contain information from nautical publications
@@ -133,7 +133,7 @@ The IMO Performance Standard divides System Database information into
 three categories that determine what data is to be on the display:
 Display Base (always present on the display); Standard Display
 (the default display); and all other information (displayed on demand).
-(MSC.530(106)/Rev.1, Appendix 2).
+(<<ref9,locality:appendix=2>>).
 
 There are 9 basic priority layers for the drawing sequence of the
 data on the display, ordered from higher to lower priorities in the
@@ -167,19 +167,19 @@ When present, the radar image should be written over Portrayal Catalogue
 display planes with a negative _order_ attribute; and below display
 planes with a positive _order_ attribute.
 
-In order to meet the requirements of IMO MSC.530(106)/Rev.1 section
-11.4.18 to adjust the ship's position, the ECDIS may incorporate the
+In order to meet the requirements of <<ref9,section="11.4.18">>
+to adjust the ship's position, the ECDIS may incorporate the
 capability of temporarily changing the radar image priority during
 the adjustment.
 
 === Displaying ECDIS updates
 
 The strategy for displaying ECDIS updates is derived from the IMO
-Performance Standard MSC.530(106)/Rev.1. The citations below are to
+Performance Standard <<ref9>>. The citations below are to
 sections in that Standard. The quoted requirements are mandatory and
 must be implemented by the ECDIS.
 
-.MSC.530(106)/Rev.1 4.4
+.<<ref9,section="4.4">>
 ____
 ECDIS should be capable of accepting official updates to the ENDS
 provided in conformity with IHO standards. These updates must be automatically
@@ -188,7 +188,7 @@ the implementation procedure must not interfere with the display in
 use.
 ____
 
-.MSC.530(106)/Rev.1 4.5
+.<<ref9,section="4.5">>
 ____
 ECDIS should also be capable of accepting updates to the ENDS data
 entered manually with simple means for verification prior to the final
@@ -198,12 +198,12 @@ legibility. (The requirements for Manual Updates are given in
 clauses 12.12.1 and 20.4.4.)
 ____
 
-.MSC.530(106)/Rev.1 4.7
+.<<ref9,section="4.7">>
 ____
 ECDIS should allow the mariner to display updates in order to review
 their contents and to ascertain that they have been included in the
 system database. (The requirements for displaying updates for review
-are given in <<sec_12.12.4>>.).
+are given in clause 12.12.4.).
 ____
 
 === Display functions

--- a/sources/2.0.0/main/sections/10-general-rules.adoc
+++ b/sources/2.0.0/main/sections/10-general-rules.adoc
@@ -4,8 +4,7 @@
 === Symbol Specifications
 
 All symbols are specified in the Portrayal Catalogue for the respective
-Product Specifications and are defined according to S-100 Part 9
-appendix B.
+Product Specifications and are defined according to <<IHO_S_100,locality:appendix="9-B">>.
 
 Some feature types do not have a symbol. Such "no symbol" features
 may be picked up by cursor interrogation of the area.
@@ -32,7 +31,7 @@ units (pixels), depending on their complexity. A simple chart symbol
 of height 4mm should extend at least 13 pixels for a screen that just
 meets the current minimum standards for chart display size and resolution.
 
-The minimum resolution is defined by IEC 61174 and/or IEC 62288.
+The minimum resolution is defined by <<IEC_61174>> and/or <<IEC_62288>>.
 
 ==== Minimum Requirement for size and resolution
 

--- a/sources/2.0.0/main/sections/12-display-elements.adoc
+++ b/sources/2.0.0/main/sections/12-display-elements.adoc
@@ -107,7 +107,7 @@ screen as the chart display, and treated as display base. Use colour
 SCLBR.
 
 This overscale indication is required by IMO Performance Standards
-(MSC.530(106)/Rev.1) and must be shown whenever the overscale factor
+(<<ref9>>) and must be shown whenever the overscale factor
 at the vessel location (when the vessel is on screen), or at the centre
 of the screen (when the vessel is not on screen), exceeds 1.
 
@@ -182,7 +182,7 @@ of X 3.6 but would have no OVERSC01 area fill.
 As the mariner's display window moves and begins to cover an ENC that
 is of a larger *_optimumDisplayScale_*, the ECDIS must indicate when
 the ship's position enters the larger scale ENC, as required by
-MSC.530(106)/Rev.1 6.1.2.
+<<ref9,section="6.1.2">>.
 
 [[sec_12.4]]
 === Graphical indexes
@@ -419,7 +419,7 @@ A north arrow must be provided as part of the Display Base according
 to the IMO Performance Standard. The north arrow must always be shown
 at the top left corner of the chart display, just clear of the scale
 bar or latitude scale. Other requirements for the north arrow are
-defined in IEC 61174.
+defined in <<IEC_61174>>.
 
 The symbol 'NORTHAR1' must be used to indicate true north.
 It must be placed in the top left corner of the chart display, on
@@ -429,7 +429,7 @@ if the latter extends the full height of the display.
 
 [[table_2]]
 .North Arrow presentation parameters
-[cols="25,17,21,21,17"]
+[cols="a,a,a,a,a"]
 |===
 h| Symbol h| Drawing priority h| Display plane h| Display category h| Viewing group
 
@@ -439,14 +439,14 @@ h| Symbol h| Drawing priority h| Display plane h| Display category h| Viewing gr
 ==== Graticule
 
 If the ECDIS shows a graticule (listed in "other information" in IMO
-Performance Standards (MSC.530(106)/Rev.1)) the lines must use the
+Performance Standards (<<ref9>>) the lines must use the
 colour token CHBLK.
 
 ==== Display mode
 
 The ECDIS manufacturer must provide the indication of display mode
 required in the display base by IMO Performance Standards
-(MSC.530(106)/Rev.1 Appendix 2).
+(<<ref9,locality:appendix=2>>).
 
 ==== Black level adjustment symbol
 
@@ -458,8 +458,7 @@ is provided as a part of ECDIS Chart 1, see <<sec_19.5>>
 
 ==== Detection and notification of navigational hazards
 
-The IMO Performance Standard for ECDIS MSC.530(106)/Rev.1,
-clause 11.3.7 Route planning states:
+The IMO Performance Standard for <<ref9,clause="11.3.7">> Route planning states:
 
 ____
 A graphical indication should also be given if the mariner plans a
@@ -468,7 +467,7 @@ category of point objects, such as a fixed or floating aid to navigation
 or isolated danger.
 ____
 
-Clause 11.4.6 Route monitoring states:
+<<ref9,clause="11.4.6">> Route monitoring states:
 
 ____
 ECDIS should give a warning or caution or indication as selected by
@@ -480,7 +479,7 @@ from a user-selectable category of danger
 safety contour or a user-selectable category of aid to navigation.
 ____
 
-Clause 11.4.8 Route Monitoring states:
+<<ref9,clause="11.4.8">> Route Monitoring states:
 
 ____
 A graphical indication should be given if the current or the next
@@ -508,8 +507,8 @@ image::figure-02.png["",440,325]
 
 ==== Detection of areas for which special conditions exist
 
-The IMO Performance Standard for ECDIS MSC.530(106)/Rev.1,
-clause 11.3.7 (which applies to Route Planning) states:
+The IMO Performance Standard for
+<<ref9,clause="11.3.7">> (which applies to Route Planning) states:
 
 ____
 A graphical indication should be given if the mariner plans a route
@@ -518,7 +517,7 @@ category of prohibited area or geographic area for which special conditions
 exist (see appendix 4).
 ____
 
-Clause 11.4.4 Route Monitoring states;
+<<ref9,clause="11.4.4">> Route Monitoring states;
 
 ____
 ECDIS should give a warning or caution, or indication, as selected
@@ -538,15 +537,14 @@ areas of the display.
 
 ==== Detection of safety contour
 
-The IMO Performance Standard for ECDIS MSC.530(106)/Rev.1,
-clause 11.3.6 Route Planning states;
+The IMO Performance Standard for <<ref9,clause="11.3.6">> Route Planning states;
 
 ____
 A graphical indication is required if the mariner plans a route closer
 than a user-specified distance from own ship's safety contour.
 ____
 
-Clause 11.4.3 Route Monitoring states;
+<<ref9,clause="11.4.3">> Route Monitoring states;
 
 ____
 It should be possible to select that ECDIS gives an alarm and related
@@ -555,7 +553,7 @@ the mariner, own ship will pass closer than a user-selected distance
 from the safety contour.
 ____
 
-Clause 11.4.7 Route Monitoring states:
+<<ref9,clause="11.4.7">> Route Monitoring states:
 
 ____
 A graphical indication should be given if the current or the next
@@ -575,8 +573,7 @@ image::figure-03.png["",461,321]
 
 ==== Indications related to ENC accuracy
 
-The IMO Performance Standard for ECDIS MSC.530(106)/Rev.1,
-clause 11.3.6 Route Planning states;
+The IMO Performance Standard for <<ref9,clause="11.3.6">> Route Planning states;
 
 ____
 11.3.8 It should be possible for the mariner to select that the indications
@@ -584,7 +581,7 @@ of 11.3.6 and 11.3.7 take into account accuracy information of relevant
 hydrographic information, as defined by IHO standards.
 ____
 
-Clause 11.4.9 Route Monitoring states;
+<<ref9,clause="11.4.9">> Route Monitoring states;
 
 ____
 11.4.9 It should be possible for the mariner to select that the indications
@@ -612,7 +609,7 @@ according to the following table of default values:
 
 [[table_3]]
 .categoryOfZoneOfConfidence and Accuracy values.
-[cols="111,68"]
+[cols="a,a"]
 |===
 h| _categoryOfZoneOfConfidence value_ h| Positional Accuracy
 
@@ -629,7 +626,7 @@ h| _categoryOfZoneOfConfidence value_ h| Positional Accuracy
 When the depth information in the S-101 is substituted by S-102 the
 __zoneOfConfidence.horizontalPositionUncertainty.__uncertaintyFixedin
 the QualityOfBathymetryCoverage feature attribute table
-(S-100 Part 10c, 9.6.2) from the S-102 must be used instead of the
+(<<IHO_S_100,clause="10c-9.6.2">>) from the S-102 must be used instead of the
 S-101 feature information as defined in the last clause if it is set.
 If this value is not available then the S-101 value defined in the
 previous clause must be used instead.
@@ -739,7 +736,7 @@ available for display for a position selected by the Mariner.
 
 [[table_4]]
 .Legend elements
-[cols="203,365"]
+[cols="a,a"]
 |===
 h| ECDIS Legend Item h| Values
 
@@ -797,18 +794,18 @@ selected and the contour displayed must be quoted
 _referenceYearForMagneticVariation (RYRMGV)_, _valueofAnnualChangeInMagneticVariation (VALACM)_,
 and _valueOfMagneticVariation (VALMAG)_ Item must be displayed as:
 VALMAG RYRMGV (VALACM) +
-For example, 4°15W 1990 (8'E)
+For example, stem:[4"unitsml(deg)"15"W"] 1990 (8'E)
 | Date and number of latest update affecting the ENC each dataset
 currently in use
 | Issue date and update number from the dataset discovery record
 (S100_DatasetDiscoveryMetadata) of the last update dataset applied.
-(See S-100 Part 17)
+(See <<IHO_S_100,part=17>>)
 
 | Edition number and date of each dataset the ENC currently in use
 | Edition number and issue date from the dataset discovery record
 
 (S100_DatasetDiscoveryMetadata) of the current base issue of the ENC
-dataset. (See S-100 Part 17)
+dataset. (See <<IHO_S_100,part=17>>)
 | Display projection | Projection used for the ECDIS display
 (For example, oblique azimuthal). This must be appropriate to the
 scale and latitude of the data in use
@@ -865,7 +862,7 @@ but will not be otherwise displayed.
 ==== Additional Mariner's Information
 
 Mariner's Caution Notes and a Mariner's Information Notes must be
-presented according to IEC 61174 or IEC 62288, as applicable [and
+presented according to <<IEC_61174>> or <<IEC_62288>>, as applicable [and
 available].
 
 Point cautions and notes entered by the mariner and the manufacturer
@@ -873,9 +870,9 @@ must be distinguished by the colours orange and yellow respectively.
 
 ==== Automatic Updates
 
-Only ISO8211 and GML encoded data can support updates, as described
-in S-100 Part 10a and 10b respectively. The use of GML updates as
-described in S-100 Part 10b is used, in particular, by S-128 to update
+Only ISO 8211 and GML encoded data can support updates, as described
+in <<IHO_S_100,part=10a>> and <<IHO_S_100,part=10b>> respectively. The use of GML updates as
+described in <<IHO_S_100,part=10b>> is used, in particular, by S-128 to update
 catalogue information used by the ECDIS to produce update Status Reports,
 as described in <<annexC>> - ECDIS Update Status Reports.
 

--- a/sources/2.0.0/main/sections/13-coverages.adoc
+++ b/sources/2.0.0/main/sections/13-coverages.adoc
@@ -3,7 +3,7 @@
 == Coverages and Time Series for Gridded Data (S-102, S-104 and S-111)
 
 Coverage and time series features are encoded in the HDF5 format
-(see S-100 Part 10c). S-100 provides for the following types of coverage
+(see <<IHO_S_100,part="10c">>). S-100 provides for the following types of coverage
 and time series data:
 
 * Gridded data with different types of spatial grid coverages;
@@ -44,7 +44,7 @@ or other algorithms of their own devising.
 The metadata variables related to time are _dateTimeOfFirstRecord_,
 _dateTimeOfLastRecord_, _timeRecordInterval_, _numberOfTimes,
 timeIntervalIndex, timePoint, startDateTime,_ and _endDateTime_
-(see S-100 Part 10c). The time selected for display (that is,
+(see <<IHO_S_100,part="10c">>). The time selected for display (that is,
 past/present/future) will typically not correspond exactly to the
 timestamp (metadata variable _timePoint_) of the input data.
 For a correct display, the ECDIS must select the correct data.

--- a/sources/2.0.0/main/sections/16-alerts.adoc
+++ b/sources/2.0.0/main/sections/16-alerts.adoc
@@ -1,10 +1,11 @@
 
 == Alerts and Indications
 
-IMO Resolution MSC.530(106)/Rev.1 states in 11.3 and 11.4 and their
+<<ref9>> states in <<ref9,section="11.3">> and <<ref9,section="11.4">> and their
 sub-paragraphs how an ECDIS should respond to risk of crossing, dangers,
 prohibited areas or areas with special conditions, during route planning
-(11.3) or route monitoring (11.4). Appendix 4 and Appendix 5 of the
+(<<ref9,section="11.3">>) or route monitoring (<<ref9,section="11.4">>).
+<<ref9,locality:appendix=4>> and <<ref9,locality:appendix=5>> of the
 same resolution provide details about the areas for which an ECDIS
 should detect incursions and provide an alert or indication.
 

--- a/sources/2.0.0/main/sections/18-dual-fuel.adoc
+++ b/sources/2.0.0/main/sections/18-dual-fuel.adoc
@@ -15,7 +15,7 @@ ENCs during the transition period.
 
 The display of additional information layers is generally driven by
 mariner need. The Interoperability Catalogue concept for ECDIS
-(see S-100 Part 16 and S-98) is based on the use of S-101 ENCs as
+(see <<IHO_S_100,part=16>> and S-98) is based on the use of S-101 ENCs as
 the base layer.
 
 === Concurrent applicability of S-52 and S-57

--- a/sources/2.0.0/main/sections/20-dataset-management.adoc
+++ b/sources/2.0.0/main/sections/20-dataset-management.adoc
@@ -68,12 +68,12 @@ a| A.B.image:figure-x.png["",16,16]
 Each dataset has a product specification edition number contained
 within it. These are located as follows:
 
-. ISO8211 datasets (S-100 Part 10a). The "PRED" field of the DSID
+. ISO 8211 datasets (<<IHO_S_100,part=10a>>). The "PRED" field of the DSID
 record in the dataset.
-. GML Datasets (S-100 Part 10b). The "ProductEdition" element of the
+. GML Datasets (<<IHO_S_100,part=10b>>). The "ProductEdition" element of the
 DatasetIdentification element in the GML dataset header.
-. HDF5 datasets (S-100 Part 10c) - Root Group "Product Specification"
-metadata value, S-100 Part 10c
+. HDF5 datasets (<<IHO_S_100,part=10c>>) - Root Group "Product Specification"
+metadata value, <<IHO_S_100,part=10c>>
 
 And have the following common format:
 
@@ -155,7 +155,7 @@ is not needed in these cases.
 ==== Introduction
 
 The current Editions of S-65, S-57 and S-63 continue to apply to the
-production and data delivery for S-57 ENC updates. S-52 Appendix I
+production and data delivery for S-57 ENC updates. <<IHO_S_52,locality:appendix="I">>
 continues to apply to the processing of S-57 updates on ECDIS.
 
 ==== General requirements
@@ -179,7 +179,7 @@ and edition numbers for S-101 ENC
 NOTE: (informative) Sequences are determined by the update and Edition
 numbers, not by issue date and time. Issue date/time are given in
 dataset discovery metadata in the Exchange Catalogue
-(see S-100 Part 17). Note that time is optional. Note also that it
+(see <<IHO_S_100,part=17>>). Note that time is optional. Note also that it
 is possible for the date/time for two or more consecutive updates
 to be the same - in fact for data that are frequently updated, such
 as water levels, the date may be the same for many consecutive datasets.
@@ -187,11 +187,11 @@ as water levels, the date may be the same for many consecutive datasets.
 ==== Automatic Update
 
 . *Reception of Updates.* The ECDIS must be capable of receiving official
-updates, as S-100 Part 17 exchange set.For such updates of S-124 and
+updates, as <<IHO_S_100,part=17>> exchange set.For such updates of S-124 and
 S-129 datasets, the ECDIS should footnote:[In the next operational
 version of S-98, "should" to be changed to "must" and the constraint
 to S-124 and S-129 to be removed.] be capable of being interfaced
-to a SECOM (IEC 63173-2) based telecommunication network. This capability
+to a SECOM (<<IEC_63173_2>>) based telecommunication network. This capability
 should include at least:
 
 .. [[item_i]]User selection of data services from a list provided
@@ -202,7 +202,7 @@ for example SECOM subscription status, and
 +
 --
 NOTE: (informative) The bi-directional transfer of S-421 based route
-plans using SECOM is described in IEC 61174, IEC 63173-1 and IEC 63173-2.
+plans using SECOM is described in <<IEC_61174>>, <<IEC_63173_1>> and <<IEC_63173_2>>.
 --
 
 . *Sequence Check*. Where data products support sequential updating
@@ -210,8 +210,8 @@ the ECDIS must ensure updates are always applied in uninterrupted
 sequence.
 . *Data Integrity and Authentication Check*. All exchange set contents
 require the use of digital signatures and the ECDIS must authenticate
-all updates using the applicable procedures described in S-100
-Part 15. All updates that do not pass the authentication and data
+all updates using the applicable procedures described in
+<<IHO_S_100,part=15>>. All updates that do not pass the authentication and data
 integrity check must not be applied. The user must be informed of
 any authentication or data integrity anomalies (refer to SSE codes).
 Update authentication and data integrity related messages for the
@@ -267,7 +267,7 @@ coverage data products should be kept in mind. After a re-issue, subsequent
 updates may be incorporated from this reissue or from the original
 data kept continuously updated.
 * Cancellation - delete the cancelled dataset and its updates as per
-S-100 17-4.4.1. The system must report any dataset(s) that have been
+<<IHO_S_100,clause="17-4.4.1">>. The system must report any dataset(s) that have been
 identified as cancelled at load time. A message must be displayed
 informing the user of the dataset name. Depending on the method adopted
 by the OEM for managing cancelled datasets one of the following conditions

--- a/sources/2.0.0/main/sections/21-dataset-support.adoc
+++ b/sources/2.0.0/main/sections/21-dataset-support.adoc
@@ -24,7 +24,7 @@ base dataset.
 
 === Management of automatic updates to Dataset Support files
 
-Dataset names in S-100 are unique (IHO_S_100,part=17>>). Dataset support
+Dataset names in S-100 are unique (<<IHO_S_100,part=17>>). Dataset support
 files are referenced to one or more datasets in the exchange catalogue
 metadata. This allows dataset support files to be shared between multiple
 datasets.

--- a/sources/2.0.0/main/sections/21-dataset-support.adoc
+++ b/sources/2.0.0/main/sections/21-dataset-support.adoc
@@ -10,9 +10,9 @@ System database. There is no requirement to import or update any other
 content from an exchange set. This includes any of S-100's component
 schemas and system support files associated with those schemas.
 
-As defined in S-100 Part 17, each dataset support file references
+As defined in <<IHO_S_100,part=17>>, each dataset support file references
 one or more datasets which contain a reference to it. Language packs
-(S-100 Part 18) reference the feature catalogue they refer to.
+(<<IHO_S_100,part=18>>) reference the feature catalogue they refer to.
 
 === Exchange set delivery
 
@@ -24,7 +24,7 @@ base dataset.
 
 === Management of automatic updates to Dataset Support files
 
-Dataset names in S-100 are unique (S-100 Part 17). Dataset support
+Dataset names in S-100 are unique (IHO_S_100,part=17>>). Dataset support
 files are referenced to one or more datasets in the exchange catalogue
 metadata. This allows dataset support files to be shared between multiple
 datasets.
@@ -53,7 +53,7 @@ is not used by any other datasets prior to deletion.
 
 From all possible support file formats, ECDIS must at least be able
 to display the following (taken from the list of support file formats
-in S-100 Part 17 S100_SupportFileFormat enumeration)
+in <<IHO_S_100,part=17>> S100_SupportFileFormat enumeration)
 
 * Plain text
 * JPEG 2000

--- a/sources/2.0.0/main/sections/ab-data-import.adoc
+++ b/sources/2.0.0/main/sections/ab-data-import.adoc
@@ -229,7 +229,7 @@ PERMIT.XML contents (after the PERMIT.XML is successfully authenticated
 against the digital signature in the PERMIT.SIGN) and its contents
 in respect of the end user's subscription details. This is only for
 use with datasets which are encrypted and should be carried out prior
-to dataset file decryption according to S-100 Part 15.
+to dataset file decryption according to <<IHO_S_100,part=15>>.
 
 [[fig_7]]
 .Check for permit validity prior to dataset decryption
@@ -244,7 +244,7 @@ diagram illustrates how signatures must be processed.
 .Authentication of Exchange Set dataset components
 image::figure-08.png["",628,482]
 
-Under S-100 Part 15 datasets and other Exchange Set components may
+Under <<IHO_S_100,part=15>> datasets and other Exchange Set components may
 have multiple digital signatures, with each signature referenced to
 a signed public key certificate. Each Exchange Set contains all relevant
 certificates with the exception of the SA digital certificate which
@@ -257,7 +257,7 @@ If more than one signature exists for a dataset or dataset support
 file then all signatures must be verified before successful import.
 
 Full documentation of authentication processes and technical details
-are contained in S-100 Part 15.
+are contained in <<IHO_S_100,part=15>>.
 
 Certain Exchange Set contents control the behaviour of the ECDIS and
 may only be digitally signed by the Scheme Administrator. These categories

--- a/sources/2.0.0/main/sections/ac-ecdis.adoc
+++ b/sources/2.0.0/main/sections/ac-ecdis.adoc
@@ -35,7 +35,7 @@ is up to date for a section of a particular route
 is up to date.
 
 All S-100 datasets use Edition and, sometimes, update numbers to denote
-their individual revision (see S-100 Part 17 for details). These numbers
+their individual revision (see <<IHO_S_100,part=17>> for details). These numbers
 uniquely identify how up to date a dataset is. The difficulty with
 using Edition/update numbers in isolation is that they do not document
 the date of revision of all datasets relative to the installation
@@ -67,9 +67,9 @@ S-128 dataset). The equipment manual should explain terms "up to date"
 and "out of date".
 
 This report only reports the status of datasets delivered as part
-of a data service using S-100 Part 17 Exchange Set metadata and
+of a data service using <<IHO_S_100,part=17>> Exchange Set metadata and
 (as part of dual-fuel mode) IHO S-57 datasets (as illustrated in the
-hybrid Exchange Set in S-100 Part 17, clause 17-4.2). Where other
+hybrid Exchange Set in <<IHO_S_100,clause="17-4.2">>). Where other
 S-100 datasets are installed on the system from other sources
 (for example, Unencrypted ENCs) then they should be displayed with
 a status of "unknown". The Equipment manual should explain terms "unknown".
@@ -238,7 +238,7 @@ a|
 | The data used as the reference for the status of each of the cells.
 This is the issue date of the last S-128 dataset in the Exchange Set
 used to update the System Database. The date is taken from the latest
-S-128 datasets issueDate in the CATALOG.XML and is expressed in ISO8601
+S-128 datasets issueDate in the CATALOG.XML and is expressed in ISO 8601
 notation:[*YYYMMDDZHHMMSS*]
 
 a|

--- a/sources/2.0.0/main/sections/ad-enhanced-safety.adoc
+++ b/sources/2.0.0/main/sections/ad-enhanced-safety.adoc
@@ -19,8 +19,8 @@ over 10 metres deeper than the value set by the user. The Enhanced
 Safety Contour feature addresses this issue.
 
 The contents of this Appendix are not currently integrated with the
-existing S-100 portrayal mechanisms specified in S-100 Edition 5.2.0
-Part 9. This may be rectified in future editions of S-100. Until then,
+existing S-100 portrayal mechanisms specified in <<IHO_S_100,part=9>>.
+This may be rectified in future editions of S-100. Until then,
 this appendix contains the normative specification for these features
 and may use different language, terms and conventions than S-100 itself.
 
@@ -73,7 +73,7 @@ to select which dataset (or data producer) they wish to use.
 grid. Nearest neighbour is used to define the depth in each S-102
 point's neighbourhood (that is, the same depth everywhere within the
 grid square), regardless of any interpolationType defined for the
-S-102 dataset (S-100 Part 8, clause 8-7.1.4), as illustrated by <<fig_D-1-2;and!fig_D-1-3>>:
+S-102 dataset (<<IHO_S_100,clause="8-7.1.4">>), as illustrated by <<fig_D-1-2;and!fig_D-1-3>>:
 +
 --
 [[fig_D-1-2]]
@@ -81,7 +81,7 @@ S-102 dataset (S-100 Part 8, clause 8-7.1.4), as illustrated by <<fig_D-1-2;and!
 image::figure-d-1-2.png["",261,227]
 
 [[fig_D-1-3]]
-.Extents of each S-102 points showing nearest neighbour interpolation (S-100 Part 8-7.1.4)
+.Extents of each S-102 points showing nearest neighbour interpolation (<<IHO_S_100,part="8-7.1.4">>)
 image::figure-d-1-3.png["",438,173]
 --
 
@@ -220,8 +220,8 @@ one of the three different options must be used:
 case the user also specifies:
 
 .. A distance parameter, the limit of the check area as specified
-by IMO MSC 530(106) 11.3.5 when route planning and MSC.530(106)/Rev.1
-11.4.4 when route monitoring.
+by <<ref9,section="11.3.5">> when route planning and <<ref9,section="11.4.4">>
+ when route monitoring.
 .. A time resolution stem:[t_u] used to construct the individual WLA
 sections. This time resolution reflects the uncertainty or tolerance
 of the time schedule of the route, for example 10 minutes if the user
@@ -550,7 +550,7 @@ those specifically excluded in this section.
 
 Soundings are included (either individual soundings or those which
 are part of an array) substituting the S-102 grid cell whose extents
-intersect the sounding position for the defined ZCOO (ISO8211),
+intersect the sounding position for the defined ZCOO (ISO 8211),
 see <<fig_D-3-18>>.
 
 If the depth substituted S-101 feature is covered by S-104, then WLA

--- a/sources/2.0.0/main/sections/ae-dataset-loading.adoc
+++ b/sources/2.0.0/main/sections/ae-dataset-loading.adoc
@@ -21,7 +21,7 @@ are to be displayed.
 NOTE: These algorithms only address loading and display related to
 visualization within the system graphics window. The application may
 need to load other datasets to satisfy requirements related to alerts
-processing, such as MSC.530(106)/Rev.1 A11.2.
+processing, such as <<ref9,section="A11.2">>.
 
 NOTE: Light sectors and other features which may span dataset boundaries.
 It should be possible, on request, for the mariner to be capable of
@@ -241,10 +241,10 @@ is then rendered using the _RenderInstruction_ algorithm.
 ^*^ The __viewingGroup(s)__, __scaleMinimum__, _scaleMaximum, date
 dependency, line suppression, and any other_ properties of the drawing
 instruction which may affect the instructions visibility must be taken
-into account. (See S-100 Part 9).
+into account. (See <<IHO_S_100,part=9>>).
 
 ^**^ To enhance the readability of text, an implementation may consider
-the guidance in S-100 Part 9 regarding text rendering to adjust this
+the guidance in <<IHO_S_100,part=9>> regarding text rendering to adjust this
 algorithm as needed.
 ====
 

--- a/sources/2.0.0/main/sections/af-gml.adoc
+++ b/sources/2.0.0/main/sections/af-gml.adoc
@@ -7,7 +7,7 @@
 
 ==== Introduction
 
-GML is used as an integral part of S-100 Part 17, specifically in
+GML is used as an integral part of <<IHO_S_100,part=17>>, specifically in
 the XML elements defined by the Exchange Catalogue Schema.
 
 For the purpose of representing coverage objects in CATALOG.XML, however

--- a/sources/2.0.0/main/sections/ag-thinning-algorithms.adoc
+++ b/sources/2.0.0/main/sections/ag-thinning-algorithms.adoc
@@ -143,7 +143,7 @@ example, counting displayable rows and columns starting with the first
 instance of a maximised symbol may suppress significant information
 in nearby grid points and produce the wrong overall impression.
 In <<fig_G-1-3>>, row 2 would be suppressed even if all the data points
-in that row are of the same size as the symbol at (1,1) — this would
+in that row are of the same size as the symbol at (1,1) -- this would
 suppress more data points with scaled-up symbols, which may represent
 data of more significance to the Mariner.
 

--- a/sources/2.0.0/main/sections/ah-import.adoc
+++ b/sources/2.0.0/main/sections/ah-import.adoc
@@ -44,17 +44,17 @@ and that stem:[b = 6356752.31425]
 For all UTM South zones, false northing stem:[FN = 10000000 "unitsml(m)"]
 --
 
-. Each UTM zone has a corresponding central meridian stem:[λ_0], which
+. Each UTM zone has a corresponding central meridian stem:[lambda_0], which
 can be found in the EPSG dataset. North and south zones of the same
 number (e.g., UTM Zone 18N and UTM Zone 18S) share a central meridian.
 
 Algorithmically, the value can be found as follows:
 
 For zone numbers stem:[N_z] between 1 and 30 (inclusive):
-stem:[λ_0 = [183-(6 xx N_z)\] "unitsml(deg)" W]
+stem:[lambda_0 = [183-(6 xx N_z)\] "unitsml(deg)" W]
 
 For zone numbers stem:[N_z] between 31 and 60 (inclusive):
-stem:[λ_0 = {[6 xx (N_z-30)\] - 3} "unitsml(deg)" E]
+stem:[lambda_0 = {[6 xx (N_z-30)\] - 3} "unitsml(deg)" E]
 
 [example]
 For UTM Zone 45S, stem:[N_z = 45], so stem:[lambda_0 = 87 "unitsml(deg)"E].

--- a/sources/2.0.0/part-a/document.adoc
+++ b/sources/2.0.0/part-a/document.adoc
@@ -378,7 +378,7 @@ the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
 or interpretable code or rules, etc, in a non-XML syntax. It may be
-enclosed in a `<![CDATA[…]]>` section so that XML validators treat it
+enclosed in a `<![CDATA[...]]>` section so that XML validators treat it
 as character data instead of XML.
 --
 
@@ -426,7 +426,7 @@ harbormaster's office or port authority                                         
 | company   | Prepared according to requirements specified by the owner,
 charterer, or operator                                                                  | 6
 | pilot     | Prepared according to requirements specified by a pilot                   | 7
-| master    | Prepared according to requirements specified by the vessel’s master       | 8
+| master    | Prepared according to requirements specified by the vessel's master       | 8
 
 |===
 
@@ -822,3 +822,10 @@ Level 1 does not define Feature Catalogues.
 
 Level 1 does not define Portrayal Catalogues.
 
+[bibliography]
+== Bibliography
+
+* [[[S98,dropid(repo:(current-metanorma-collection/IHO S-98))]]],
+span:title[S-98 -- Part 1: Conceptual Schema Language],
+span:edition[5.2.0],
+span:organization[International Hydrographic Organization]

--- a/sources/2.0.0/part-a/document.adoc
+++ b/sources/2.0.0/part-a/document.adoc
@@ -152,7 +152,7 @@ all S-98 Interoperability Catalogues and S-98 Exchange Sets;
 model and Catalogue encoding that are specific to Level 1 interoperability.
 
 The hypothetical processing model for implementations is described
-in general terms in the "S-98 - Main" document and elaborated in <<sec_A-7>>
+in general terms in <<S98>> and elaborated in <<sec_A-7>>
 of this Part.
 
 In Level 1 processing, feature types from different products, including
@@ -178,11 +178,11 @@ to Interoperability Catalogues designated as Level 1.
 
 For <<sec_A-3;to!sec_A-10>>, the content of the clause or sub-clause
 extends or elaborates on the content under the same or similar clause
-heading or sub-heading in the S-98 - Main document.
+heading or sub-heading in <<S98>>.
 
 The numbering of <<sec_A-3;to!sec_A-10>> may differ from that of corresponding
-clauses in S-98 - Main, because for some there is no additional Level-specific
-information needed. If a clause or sub-clause in S-98 - Main has no
+clauses in <<S98>>, because for some there is no additional Level-specific
+information needed. If a clause or sub-clause in <<S98>> has no
 corresponding clause or sub-clause in this Part, there is no Level-specific
 information on that topic.
 
@@ -190,7 +190,7 @@ information on that topic.
 == Specification Scope for Part A
 
 S-98 Part A describes the portions of S-98 which correspond to the
-following scope defined in S-98 - Main (clause 2):
+following scope defined in <<S98,clause=2>>:
 
 *Scope Identification:* S98L1
 
@@ -213,7 +213,7 @@ EX_GeographicBoundingBox = [-180, +180, -90, +90]
 
 The Application Schema for Interoperability Level 1 is depicted in
 <<fig_A-3.1>> below. This Application Schema is a subset of the full
-Application Schema in S-100 Part 16. It consists of the following
+Application Schema in <<IHO_S_100,part=16>>. It consists of the following
 components:
 
 . Catalogue header information.
@@ -229,13 +229,13 @@ image::figure-a-3-1.png[]
 ==== Operations in pre-defined combinations
 
 Operations in predefined combinations are possible only in Levels
-2, 3, and 4 (Parts B, C, D).
+2, 3, and 4 (<<PartB>>, <<PartC>>, <<PartD>>).
 
 [[sec_A-3.1.3]]
 ==== Enhanced selection of feature instances
 
 Enhanced selection of feature instances is possible only in Levels
-3 and 4 (Parts C and D).
+3 and 4 (<<PartC>> and <<PartD>>).
 
 [[sec_A-3.1.4]]
 ==== Interoperability Levels
@@ -250,13 +250,13 @@ plane pertains.
 ==== Hybridization rules
 
 Hybridization rules are allowed only in Levels 3 and 4
-(Parts C and D).
+(<<PartC>> and <<PartD>>).
 
 [[sec_A-3.1.6]]
 ==== Hybrid Feature and Portrayal Catalogues
 
 Hybrid Feature and Portrayal Catalogues are allowed only in Levels
-3 and 4 (Parts C and D).
+3 and 4 (<<PartC>> and <<PartD>>).
 
 [[sec_A-3.1.7]]
 ==== Progression of Interoperability Levels
@@ -272,7 +272,7 @@ is no interoperability Schema) to Level 1 interoperability.
 
 The following clauses summarize the conceptual elements used in Level
 1 Interoperability Catalogues. Details about these conceptual types
-are provided in S-100 Part 16.
+are provided in <<IHO_S_100,part=16>>.
 
 [[sec_A-3.2.1.1]]
 ===== Display plane (S100_IC_DisplayPlane)
@@ -313,7 +313,7 @@ with drawing instructions instead of feature objects. The
 *S100_IC_DrawingInstruction* element in Interoperability Catalogues
 is similar in operation to the layering and priority aspects of the
 *DrawingInstruction* element in Portrayal Catalogues
-(see S-100 Part 9 - Portrayal). Where there is a conflict with a Portrayal
+(see <<IHO_S_100,part=9>> - Portrayal). Where there is a conflict with a Portrayal
 Catalogue drawing instruction, the drawing instruction in the Interoperability
 Catalogue supersedes the drawing instruction in the Portrayal Catalogue.
 
@@ -343,7 +343,7 @@ all Catalogues where substitution of symbolization is necessary.
 ==== Use of S-100 types
 
 The S-100 types used by S-98 Level 1 Interoperability Catalogues are
-described in the S-98 - Main document. For Level 1 Interoperability
+described in <<S98>>. For Level 1 Interoperability
 Catalogues, the following additional information applies.
 
 * Interoperability Catalogues of Level 1 do not use feature and information
@@ -351,13 +351,13 @@ associations in feature filters.
 
 === UML model documentation
 
-The UML model documentation is provided in S-100 Part 16. This clause
+The UML model documentation is provided in <<IHO_S_100,part=16>>. This clause
 documents details specific to the use of the UML model for the interoperability
 Level described in this Part of S-98.
 
 Only the model elements used in this Level (and included in the Level's
 Application Schema) are listed. The constraints and considerations
-listed in the UML documentation tables in S-100 Part 16 apply. Any
+listed in the UML documentation tables in <<IHO_S_100,part=16>> apply. Any
 S-98 general or Level-specific considerations are described under
 the element name in the list below.
 
@@ -372,8 +372,8 @@ Catalogues is 1.
 . *S100_IC_DrawingInstruction*:
 +
 --
-NOTE: for implementers: Even if the Presentation Schema in S-100 Part
-9 is used, implementers may need to provide specific code to validate
+NOTE: for implementers: Even if the Presentation Schema in <<IHO_S_100,part=9>>
+is used, implementers may need to provide specific code to validate
 the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
@@ -405,7 +405,7 @@ MRN: urn:mrn:iho:prod:s98:1:0:0:products.
 . *Codelist requirementType*: No Level-specific constraints or notes.
 
 For all interoperability Levels, the following subset of the standard
-values listed in S-100 Part 16 are permitted to be used in S-98 Interoperability
+values listed in <<IHO_S_100,part=16>> are permitted to be used in S-98 Interoperability
 Catalogues:
 
 [[table_A-3.1]]
@@ -431,7 +431,7 @@ charterer, or operator                                                          
 |===
 
 
-Extra values ("other: ...") as defined in S-100 Part 3, clause 3-6.7
+Extra values ("other: ...") as defined in <<IHO_S_100,clause="3-6.7">>
 are also permitted.
 
 [[sec_A-4]]
@@ -440,8 +440,7 @@ are also permitted.
 [[sec_A-4.1]]
 === Quality of displayed data
 
-There are no Level-specific extensions to clause 6.1 of the
-"S98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.1">>.
 
 <<sec_A-5.11>> provides guidance for maintaining data quality for
 Level-specific rules and operations.
@@ -449,29 +448,27 @@ Level-specific rules and operations.
 [[sec_A-4.2]]
 === Quality of interoperability catalogues
 
-The quality measures recommended in S-97 (Part C) which are applicable
+The quality measures recommended in <<S97,part=C>> which are applicable
 to Level 1 S-98 Interoperability Catalogues are those listed in
-Table 6-1 of the "S-98 - Main" document. There are no additional Level-specific
+<<S98,table="6-1">> document. There are no additional Level-specific
 measures for Level 1.
 
 [[sec_A-4.2.1]]
 ==== Test methods
 
-There are no Level-specific extensions to clause 6.2.1 of the
-"S-98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.2.1">>.
 
 [[sec_A-4.2.2]]
 ==== Data quality testing
 
-There are no Level-specific extensions to clause 6.2.2 of the
-"S-98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.2.2">>.
 
 [[sec_A-5]]
 == Level-Specific Guidance on Making Product Specifications Interoperable
 
 The guidelines in this clause supplement and extend guidance common
 to all Levels on making Product Specifications interoperable, which
-is given in clause 8 of the "S-98 - Main" document.
+is given in <<S98,clause=8>>.
 
 === Duplicated features
 
@@ -488,17 +485,17 @@ drawing priority or in an upper display plane will still be visible.
 [[sec_A-5.1.1]]
 ==== Duplicated features same model
 
-See the guidance in clause 8.1.1 of the "S-98 - Main" document.
+See the guidance in <<S98,clause="8.1.1">>.
 
 [[sec_A-5.1.2]]
 ==== Duplicated features, different models
 
-See the guidance in clause 8.1.2 of the "S-98 - Main" document.
+See the guidance in <<S98,clause="8.1.2">>.
 
 [[sec_A-5.1.3]]
 ==== Duplicate feature domains
 
-See the guidance in clause 8.1.3 of the "S-98 - Main" document.
+See the guidance in <<S98,clause="8.1.3">>.
 
 === Geometry
 
@@ -506,30 +503,30 @@ See the guidance in clause 8.1.3 of the "S-98 - Main" document.
 ==== Combined geometry
 
 Combined geometry is possible only in Interoperability
-Levels 3 and 4 (Parts C and D of this Specification).
+Levels 3 and 4 (<<PartC>> and <<PartD>> of this Specification).
 
 [[sec_A-5.2.2]]
 ==== Spatial discrepancy, unrelated to scaled or cartographic smoothing
 
 Resolution of this type of spatial discrepancy is possible only in
-Levels, 2, 3, and 4 (Parts B, C, and D of this Specification).
+Levels, 2, 3, and 4 (<<PartB>>, <<PartC>>, and <<PartD>> of this Specification).
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.2">>.
 
 [[sec_A-5.2.3]]
 ==== Spatial discrepancies, related to scale or cartographic smoothing
 
 Resolution of this type of spatial discrepancy is possible only in
-Levels, 2, 3, and 4 (Parts B, C, and D of this specification).
+Levels, 2, 3, and 4 (<<PartB>>, <<PartC>>, and <<PartD>> of this specification).
 
 There is no level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.3 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.3">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 === Skin-of-the-earth feature operations
 
@@ -549,13 +546,13 @@ See <<sec_A-6.9>> for portrayal considerations.
 ==== Skin-of-the earth feature adjusting
 
 Adjustment of the geometry of skin-of-the-earth features is possible
-only in Level 4 (Part D).
+only in Level 4 (<<PartD>>).
 
 [[sec_A-5.5]]
 === Blended feature concepts
 
 Blended features or blended portrayal are only possible in interoperability
-Levels 3 and 4 (Parts C and D).
+Levels 3 and 4 (<<PartC>> and <<PartD>>).
 
 === Hierarchy of data
 
@@ -570,25 +567,25 @@ rules.
 ==== Predefined combinations
 
 Predefined combinations can be defined only in Level 2, 3, or 4 Interoperability
-Catalogues (Parts B, C, and D).
+Catalogues (<<PartB>>, <<PartC>>, and <<PartD>>).
 
 [[sec_A-5.7]]
 === New datasets
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.7">>.
 
 [[sec_A-5.8]]
 === Dataset scales, loading, and unloading
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.8">>.
 
 [[sec_A-5.9]]
 === Metadata
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.9 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.9">>.
 
 [[sec_A-5.10]]
 === Meta-features
@@ -597,13 +594,13 @@ Any spatial operations on meta-features require an Interoperability
 Catalogue to implement at least Level 4.
 
 There is no other Level-specific guidance for meta-features. Common
-guidance is provided in clause 8.10 of the "S-98 - Main" document.
+guidance is provided in <<S98,clause="8.10">>.
 
 [[sec_A-5.11]]
 === Quality considerations
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.11 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.11">>.
 
 == Portrayal
 
@@ -618,48 +615,48 @@ are external to the Interoperability Catalogue; in such cases the
 Interoperability Catalogue should continue to function in the presence
 of products not defined in the Catalogue. Data products that are outside
 of the interoperability scope must be treated in Interoperability
-Level 0 (see clause 9.6 of the "S-98 - Main" document).
+Level 0 (see <<S98,clause="9.6">>).
 
 === Display of significant features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.1 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.1">>.
 
 === Display of significant features - switching to original
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.2">>.
 
 === Portrayal distinguishability - colour set-asides
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.3 of the "S-98 - Main" document. See also
-S-100 Part 16 for specific guidance on colour set-asides.
+is provided in <<S98,clause="10.3">>. See also
+<<IHO_S_100,part=16>> for specific guidance on colour set-asides.
 
 === Day/night/dusk modes
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.4 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.4">>.
 
 === Impacts on viewing groups
 
 There is no level-specific guidance for this issue. Common guidance
-is provided in clause 10.5 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.5">>.
 
 === Impacts on Portrayal Catalogues
 
 There is no level-specific guidance for this issue. Common guidance
-is provided in clause 10.6 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.6">>.
 
 === Meta-features
 
 There is no level-specific guidance for this issue. Common guidance
-is provided in clause 10.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.7">>.
 
 === Display of text
 
 There is no level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 [[sec_A-6.9]]
 === Skin-of-the-earth operations and portrayal
@@ -701,16 +698,16 @@ on the corresponding features in other data layers.
 
 Changes to the location or extent of symbols displayed on the screen
 due to a feature in another dataset are only possible in interoperability
-Levels 3 and 4 (Parts C and D).
+Levels 3 and 4 (<<PartC>> and <<PartD>>).
 
 === Blended portrayals
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.10 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.10">>.
 
 === Hierarchy of data
 
-As noted in clause 11.11 of the "S-98 - Main" document, hierarchy
+As noted in <<S98,clause="11.11">>, hierarchy
 of data can be controlled by predefined combinations (Level 2 and
 higher). Level 1 Catalogues offer only a very limited means of controlling
 hierarchy by means of display plane ordering. There is no Level-specific
@@ -720,8 +717,7 @@ guidance for portrayal in connection with this issue.
 ==== Interacting gridded information
 
 There is no Level-specific guidance for portrayal in connection with
-this issue. Common guidance is provided in clause 10.11.1 of the
-"S-98 - Main" document.
+this issue. Common guidance is provided in <<S98,clause="10.11.1">>.
 
 === Pick Reports
 
@@ -729,7 +725,7 @@ NOTE: The Pick Report functionality specification in S-98 is still
 under development, and the content of this section will change as
 this functionality is defined.
 
-Clause 10.12 of the "S-98 - Main" document applies. There is no additional
+<<S98,clause="10.12">> applies. There is no additional
 Level-specific guidance for Level 1.
 
 [[sec_A-7]]
@@ -810,7 +806,7 @@ image::figure-a-7-2.png["",605,374]
 == Normative Implementation Guidance
 
 There is no level-specific normative implementation guidance in this
-Edition of S-98. See clause 17 of the "S-98 - Main" document for implementation
+Edition of S-98. See <<S98,clause=17>> for implementation
 guidance that applies to all Levels.
 
 == Feature Catalogue
@@ -826,6 +822,25 @@ Level 1 does not define Portrayal Catalogues.
 == Bibliography
 
 * [[[S98,dropid(repo:(current-metanorma-collection/IHO S-98))]]],
-span:title[S-98 -- Part 1: Conceptual Schema Language],
-span:edition[5.2.0],
+span:title[S-98 -- S-100 ECDIS and Interoperability Specification],
+span:edition[2.0.0],
 span:organization[International Hydrographic Organization]
+
+* [[[PartB,dropid(repo:(current-metanorma-collection/IHO S-98 Part B))]]],
+span:title[S-98 -- Part B: Level 2 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartC,dropid(repo:(current-metanorma-collection/IHO S-98 Part C))]]],
+span:title[S-98 -- Part C: Level 3 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartD,dropid(repo:(current-metanorma-collection/IHO S-98 Part D))]]],
+span:title[S-98 -- Part D: Level 4 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[IHO_S_100,IHO S-100]]]
+
+* [[[S97,IHO S-97]]]

--- a/sources/2.0.0/part-a/document.adoc
+++ b/sources/2.0.0/part-a/document.adoc
@@ -20,36 +20,121 @@
 
 
 [.preface]
-== Document History
+== metanorma-extension
 
+[.boilerplate]
+--
 Changes to this Specification are coordinated by the IHO S-100 Working
 Group. New editions will be made available via the IHO web site. Maintenance
 of the Specification shall conform to IHO Resolution 2/2007 (as amended).
+--
 
-[cols="14,15,14,57",options="header,unnumbered"]
-|===
-h| Version Number h| Date h| Approved By h| Purpose
+=== document history
 
-| 0.1 | 31 Jul 2017 | EM, RM | First draft.
-| 0.2 | 12 Dec 2017 | RM, EM | Changes from interoperability workshop
-and TSM5.
-| 0.3 | 08 Jul 2018 | EM, RM
-| Edits from March 2018 review commentsUpdates for conformance to
-S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items
-not used by S-98 from the metadata documentation tables.
-| 1.0.0 RC1 | 13 Mar 2019 | RM | Applied S-100 WG4 decisions; updated
-metadata to conform to final version of S-100 Edition 4.0.0.
-| 1.0.0 (Draft) | 21 Mar 2019 | JW | Editorial updates for HSSC.
-| 0.4 | Jan 2020 | RM | Revised after TSM7 decision to separate interoperability
-into an abstract specification (new S-100 Part) and implementation
-specification (S-98).
-| 1.0.0 | May 2022 | S-100WG | Submission to HSSC14 for approval.
-| 1.0.0 | May 2022 | HSSC | Initial published version for evaluation
-and testing.
-
-|===
-
-
+[source,yaml]
+----
+- date:
+  - type: updated
+    value: 2017-07-31
+  edition: "0.1"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: First draft
+- date:
+  - type: updated
+    value: 2017-12-12
+  edition: "0.2"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  amend:
+    - description: Changes from interoperability workshop and TSM5.
+- date:
+  - type: updated
+    value: 2018-07-08
+  edition: "0.3"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Edits from March 2018 review comments
+    - description: Updates for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items not used by S-98 from the metadata documentation tables.
+- date:
+  - type: updated
+    value: 2019-03-13
+  edition: "1.0.0 RC1"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Applied S-100 WG4 decisions; updated metadata to conform to final version of S-100 Edition 4.0.0.
+- date:
+  - type: updated
+    value: 2019-03-21
+  edition: "1.0.0. (Draft)"
+  contributor:
+  - person:
+      name:
+        completename: JW
+        abbreviation: JW
+  amend:
+    - description: Editorial updates for HSSC.
+- date:
+  - type: updated
+    value: 2020-01
+  edition: "0.4"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Revised after TSM7 decision to separate interoperability into an abstract specification (new S-100 Part) and implementation specification (S-98).
+- date:
+  - type: updated
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: S-100 Working Group
+      abbreviation: S-100WG
+  amend:
+    - description: Submission to HSSC14 for approval.
+- date:
+  - type: published
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: IHO Hydrographic Services and Standards Committee
+      abbreviation: HSSC
+  amend:
+    - description: Initial published version for evaluation and testing.
+----
 
 [[sec_A-1]]
 == Introduction

--- a/sources/2.0.0/part-a/document.adoc
+++ b/sources/2.0.0/part-a/document.adoc
@@ -1,7 +1,10 @@
 = Data Product Interoperability in S-100 Navigation Systems - Part A: Level 1 Interoperability
 :series: S
 :docnumber: 98
-:doctype: standard
+:partnumber: A
+:title: Data Product Interoperability in S-100 Navigation Systems
+:title-part: Level 1 Interoperability
+:doctype: specification
 :edition: 1.0.0
 :language: en
 :published-date: 2022-05-01

--- a/sources/2.0.0/part-b/document.adoc
+++ b/sources/2.0.0/part-b/document.adoc
@@ -448,7 +448,7 @@ the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
 or interpretable code or rules, etc, in a non-XML syntax. It may be
-enclosed in a <![CDATA[…]]> section so that XML validators treat it
+enclosed in a <![CDATA[...]]> section so that XML validators treat it
 as character data instead of XML.
 --
 
@@ -933,7 +933,7 @@ Included product list from S100_IC_PredefinedCombination.includedProduct
 | Suppress Feature Types
 | Suppress all instances of a specified feature type in a product
 | 2
-| S100_IC_Suppressed‌Feature‌Layer
+| S100_IC_SupressedFeatureLayer
 |
 |
 

--- a/sources/2.0.0/part-b/document.adoc
+++ b/sources/2.0.0/part-b/document.adoc
@@ -20,26 +20,121 @@
 
 
 [.preface]
-== Document History
+== metanorma-extension
 
+[.boilerplate]
+--
 Changes to this Specification are coordinated by the IHO S-100 Working
 Group. New editions will be made available via the IHO web site. Maintenance
 of the Specification shall conform to IHO Resolution 2/2007 (as amended).
+--
 
-[cols="4",options="header,unnumbered"]
-|===
-h| Version Number h| Date h| Approved By h| Purpose
+=== document history
 
-| 0.1 | 31 Jul 2017 | EM, RM | First draft.
-| 0.2 | 12 Dec 2017 | RM, EM | Changes from interoperability workshop and TSM5.
-| 0.3 | 08 Jul 2018 | EM, RM | Edits from March 2018 review commentsUpdates for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items not used by S-98 from the metadata documentation tables.
-| 1.0.0 RC1 | 13 Mar 2019 | RM | Applied S-100 WG4 decisions; updated metadata to conform to final version of S-100 Edition 4.0.0.
-| 1.0.0 (Draft) | 21 Mar 2019 | JW | Editorial updates for HSSC.
-| 0.4 | Jan 2020 | RM | Revised after TSM7 decision to separate interoperability into an abstract specification (new S-100 Part) and implementation specification (S-98).
-| 1.0.0 | May 2022 | S-100WG | Submission to HSSC14 for approval.
-| 1.0.0 | May 2022 | HSSC | Initial published version for evaluation and testing.
-
-|===
+[source,yaml]
+----
+- date:
+  - type: updated
+    value: 2017-07-31
+  edition: "0.1"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: First draft
+- date:
+  - type: updated
+    value: 2017-12-12
+  edition: "0.2"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  amend:
+    - description: Changes from interoperability workshop and TSM5.
+- date:
+  - type: updated
+    value: 2018-07-08
+  edition: "0.3"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Edits from March 2018 review comments
+    - description: Updates for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items not used by S-98 from the metadata documentation tables.
+- date:
+  - type: updated
+    value: 2019-03-13
+  edition: "1.0.0 RC1"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Applied S-100 WG4 decisions; updated metadata to conform to final version of S-100 Edition 4.0.0.
+- date:
+  - type: updated
+    value: 2019-03-21
+  edition: "1.0.0. (Draft)"
+  contributor:
+  - person:
+      name:
+        completename: JW
+        abbreviation: JW
+  amend:
+    - description: Editorial updates for HSSC.
+- date:
+  - type: updated
+    value: 2020-01
+  edition: "0.4"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Revised after TSM7 decision to separate interoperability into an abstract specification (new S-100 Part) and implementation specification (S-98).
+- date:
+  - type: updated
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: S-100 Working Group
+      abbreviation: S-100WG
+  amend:
+    - description: Submission to HSSC14 for approval.
+- date:
+  - type: published
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: IHO Hydrographic Services and Standards Committee
+      abbreviation: HSSC
+  amend:
+    - description: Initial published version for evaluation and testing.
+----
 
 [[sec_B-1]]
 == Introduction

--- a/sources/2.0.0/part-b/document.adoc
+++ b/sources/2.0.0/part-b/document.adoc
@@ -152,7 +152,7 @@ all S-98 Interoperability Catalogues and S-98 Exchange Sets;
 model and Catalogue encoding that are specific to Level 2 interoperability.
 
 The hypothetical processing model for implementations is described
-in general terms in the "S-98 - Main" document and elaborated in <<sec_B-7>>
+in general terms in the <<S98>> and elaborated in <<sec_B-7>>
 of this Part.
 
 Level 2 interoperability includes the following capabilities:
@@ -186,23 +186,23 @@ to Interoperability Catalogues designated as Level 2.
 
 For <<sec_B-3;to!sec_B-10>>, the content of the clause or sub-clause
 extends or elaborates on the content under the same or similar clause
-heading or sub-heading in the S-98 - Main document.
+heading or sub-heading in <<S98>>.
 
 The numbering of <<sec_B-3;to!sec_B-10>> may differ from that of corresponding
-clauses in S-98 - Main, because for some there is no additional Level-specific
-information needed. If a clause or sub-clause in S-98 - Main has no
+clauses in <<S98>>, because for some there is no additional Level-specific
+information needed. If a clause or sub-clause in <<S98>> has no
 corresponding clause or sub-clause in this Part, there is no Level-specific
 information on that topic.
 
-Part B includes Part A content (pertaining to Level 1), adapted as
-necessary for Level 2. Reference to Part A should therefore not be
+Part B includes <<PartA>> content (pertaining to Level 1), adapted as
+necessary for Level 2. Reference to <<PartA>> should therefore not be
 needed.
 
 [[sec_B-2]]
 == Specification Scope for Part B
 
 S-98 Part B describes the portions of S-98 which correspond to the
-following scope defined in S-98 - Main (clause 2):
+following scope defined in <<S98,clause=2>>):
 
 *Scope Identification:* S98L2
 
@@ -226,7 +226,7 @@ interleaving
 
 The Application Schema for Interoperability Level 2 is depicted in
 <<fig_B-3.1>> below. This Application Schema is a subset of the full
-Application Schema in S-100 Part 16. It consists of the following
+Application Schema in <<IHO_S_100,part=16>>. It consists of the following
 components:
 
 . Catalogue header information.
@@ -265,7 +265,7 @@ are always contained within *S100_IC_PredefinedCombination* elements.
 ==== Enhanced selection of feature instances
 
 Enhanced selection of feature instances is possible only in Levels
-3 and 4 (Parts C and D).
+3 and 4 (<<PartC>> and <<PartD>>).
 
 [[sec_B-3.1.4]]
 ==== Interoperability levels
@@ -285,13 +285,13 @@ are permitted to also include operations of a lower Level of interoperability.
 ==== Hybridization rules
 
 Hybridization rules are allowed only in Levels 3 and 4
-(Parts C and D).
+(<<PartC>> and <<PartD>>).
 
 [[sec_B-3.1.6]]
 ==== Hybrid Feature and Portrayal Catalogues
 
 Hybrid Feature and Portrayal Catalogues are allowed only in Levels
-3 and 4 (Parts C and D).
+3 and 4 (<<PartC>> and <<PartD>>).
 
 [[sec_B-3.1.7]]
 ==== Progression of Interoperability Levels
@@ -316,7 +316,7 @@ image::figure-b-3-2.png[]
 
 The following clauses summarize the conceptual elements used in Level
 2 Interoperability Catalogues. Details about these conceptual types
-are provided in S-100 Part 16.
+are provided in <<IHO_S_100,part=16>>.
 
 [[sec_B-3.2.1.1]]
 ===== Display plane (S100_IC_DisplayPlane)
@@ -364,8 +364,8 @@ role to feature type display information (*S100_IC_FeatureType*) but
 with drawing instructions instead of feature objects. The
 *S100_IC_DrawingInstruction* element in Interoperability Catalogues
 is similar in operation to the layering and priority aspects of the
-*DrawingInstruction* element in Portrayal Catalogues (see S-100 Part
-9 - Portrayal). Where there is a conflict with a Portrayal Catalogue
+*DrawingInstruction* element in Portrayal Catalogues (see <<IHO_S_100,part=9>>).
+Where there is a conflict with a Portrayal Catalogue
 drawing instruction, the drawing instruction in the Interoperability
 Catalogue supersedes the drawing instruction in the Portrayal Catalogue.
 
@@ -414,7 +414,7 @@ by means of references in the *S100_IC_PredefinedCombination* elements.
 ==== Use of S-100 types
 
 The S-100 types used by S-98 Level 2 Interoperability Catalogues are
-described in the S-98 - Main document. For Level 2 Interoperability
+described in <<S98>>. For Level 2 Interoperability
 Catalogues, the following additional information applies.
 
 * Interoperability Catalogues of Level 2 do not use feature and information
@@ -422,13 +422,13 @@ associations in feature filters.
 
 === UML model documentation
 
-The UML model documentation is provided in S-100 Part 16. This clause
+The UML model documentation is provided in <<IHO_S_100,part=16>>. This clause
 documents details specific to the use of the UML model for the interoperability
 Level described in this Part of S-98.
 
 Only the model elements used in this Level (and included in the Level's
 Application Schema) are listed. The constraints and considerations
-listed in the UML documentation tables in S-100 Part 16 apply. Any
+listed in the UML documentation tables in <<IHO_S_100,part=16>> apply. Any
 S-98 general or Level-specific considerations are described under
 the element name in the list below.
 
@@ -442,8 +442,8 @@ allowed for Level 2 Interoperability Catalogues are 1 and 2.
 . *S100_IC_DrawingInstruction*:
 +
 --
-NOTE: for implementers: Even if the Presentation Schema in S-100 Part
-9 is used, implementers may need to provide specific code to validate
+NOTE: for implementers: Even if the Presentation Schema in <<IHO_S_100,part=9>>
+is used, implementers may need to provide specific code to validate
 the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
@@ -486,7 +486,7 @@ MRN: urn:mrn:iho:prod:s98:1:0:0:products.
 +
 --
 For all interoperability Levels, the following subset of the standard
-values listed in S-100 Part 16 are permitted to be used in S-98 Interoperability
+values listed in <<IHO_S_100,part=16>> are permitted to be used in S-98 Interoperability
 Catalogues:
 
 [[table_B-3-1]]
@@ -506,7 +506,7 @@ Catalogues:
 
 |===
 
-Extra values ("other: ...") as defined in S-100 Part 3, clause 3-6.7
+Extra values ("other: ...") as defined in <<IHO_S_100,clause="3-6.7">>
 are also permitted.
 --
 
@@ -523,8 +523,7 @@ Catalogues.
 [[sec_B-4.1]]
 === Quality of displayed data
 
-There are no Level-specific extensions to clause 6.1 of the
-"S98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.1">>.
 
 <<sec_B-5.11>> provides guidance for maintaining data quality for
 Level-specific rules and operations.
@@ -532,29 +531,27 @@ Level-specific rules and operations.
 [[sec_B-4.2]]
 === Quality of interoperability catalogues
 
-The quality measures recommended in S-97 (Part C) which are applicable
+The quality measures recommended in S-97 (<<PartC>>) which are applicable
 to Level 2 S-98 Interoperability Catalogues are those listed in
-Table 6-1 of the "S-98 - Main" document. There are no additional Level-specific
+<<S98,table="6-1">>. There are no additional Level-specific
 measures for Level 2.
 
 [[sec_B-4.2.1]]
 ==== Test methods
 
-There are no Level-specific extensions to Clause 6.2.1 of the
-"S-98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.2.1">>.
 
 [[sec_B-4.2.2]]
 ==== Data quality testing
 
-There are no Level-specific extensions to Clause 6.2.2 of the
-"S-98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.2.2">>.
 
 [[sec_B-5]]
 == Level-specific Guidance on Making Product Specifications Interoperable
 
 The guidelines in this clause supplement and extend guidance common
 to all Levels on making Product Specifications interoperable, which
-is given in clause 8 of the "S-98 - Main" document.
+is given in <<S98,clause=8>>.
 
 [[sec_B-5.1]]
 === Duplicated features
@@ -583,7 +580,7 @@ functionality is added in Level 2.
 [[sec_B-5.1.1]]
 ==== Duplicated features same model
 
-See the guidance in clause 8.1.1 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.1">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
 solutions described earlier in <<sec_B-5.1>> of this Part.
 
@@ -606,7 +603,7 @@ instances with that combination will be visible, and all others suppressed.
 [[sec_B-5.1.2]]
 ==== Duplicated features, different models
 
-See the guidance in clause 8.1.2 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.2">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
 solutions described in <<sec_B-5.1>> of this Part. There is no other
 Level-specific guidance for this scenario.
@@ -614,7 +611,7 @@ Level-specific guidance for this scenario.
 [[sec_B-5.1.3]]
 ==== Duplicate feature domains
 
-See the guidance in clause 8.1.3 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.3">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
 solutions described in <<sec_B-5.1>> of this Part. There is no other
 Level-specific guidance for this scenario.
@@ -625,24 +622,24 @@ Level-specific guidance for this scenario.
 ==== Combined geometry
 
 Combined geometry is possible only in interoperability Levels 3 and
-4 (Parts C and D of this Specification).
+4 (<<PartC>> and <<PartD>> of this Specification).
 
 [[sec_B-5.2.2]]
 ==== Spatial discrepancy, unrelated to scaled or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.2">>.
 
 [[sec_B-5.2.3]]
 ==== Spatial discrepancies, related to scale or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.3 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.3">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 === Skin-of-the-earth feature operations
 
@@ -666,13 +663,13 @@ See <<sec_B-6.9>> for portrayal considerations.
 ==== Skin-of-the earth feature adjusting
 
 Adjustment of the geometry of skin-of-the-earth features is possible
-only in Level 4 (Part D).
+only in Level 4 (<<PartD>>).
 
 [[sec_B-5.5]]
 === Blended feature concepts
 
 Blended features or blended portrayal are only possible in interoperability
-Levels 3 and 4 (Parts C and D).
+Levels 3 and 4 (<<PartC>> and <<PartD>>).
 
 === Hierarchy of data
 
@@ -704,19 +701,19 @@ gives the order in which the layers are drawn.
 === New datasets
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.7">>.
 
 [[sec_B-5.8]]
 === Dataset scales, loading, and unloading
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.8">>.
 
 [[sec_B-5.9]]
 === Metadata
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.9 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.9">>.
 
 [[sec_B-5.10]]
 === Meta-features
@@ -725,13 +722,13 @@ Any spatial operations on meta-features require an Interoperability
 Catalogue to implement at least Level 4.
 
 There is no other Level-specific guidance for meta-features. Common
-guidance is provided in clause 8.10 of the "S-98 - Main" document.
+guidance is provided in <<S98,clause="8.10">>.
 
 [[sec_B-5.11]]
 === Quality considerations
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.11 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.11">>.
 
 == Portrayal
 
@@ -746,48 +743,48 @@ are external to the Interoperability Catalogue; in such cases the
 Interoperability Catalogue should continue to function in presence
 of products not defined in the Catalogue. Data products that are outside
 of the interoperability scope must be treated in Interoperability
-Level 0 (see clause 9.6 in the "S-98 - Main" document).
+Level 0 (see <<S98,clause="9.6">>).
 
 === Display of significant features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.1 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.1">>.
 
 === Display of significant features - switching to original
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.2">>.
 
 === Portrayal distinguishability - colour set-asides
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.3 of the "S-98 - Main" document. See also
-S-100 Part 16 for specific guidance on colour set-asides.
+is provided in <<S98,clause="10.3">>. See also
+<<IHO_S_100,part=16>> for specific guidance on colour set-asides.
 
 === Day/night/dusk modes
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.4 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.4">>.
 
 === Impacts on viewing groups
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.5 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.5">>.
 
 === Impacts on Portrayal Catalogues
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.6 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.6">>.
 
 === Meta-features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.7">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 [[sec_B-6.9]]
 === Skin-of-the-earth operations and portrayal
@@ -836,16 +833,16 @@ on the corresponding features in other data layers.
 
 Changes to the location or extent of symbols displayed on the screen
 due to a feature in another dataset are only possible in interoperability
-Levels 3 and 4 (Parts C and D).
+Levels 3 and 4 (<<PartC>> and <<PartD>>).
 
 === Blended portrayals
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.10 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.10">>.
 
 === Hierarchy of data
 
-As noted in clause 11.11 of the "S-98 - Main" document, hierarchy
+As noted in <<S98,clause="11.11">>, hierarchy
 of data can be controlled by predefined combinations. There is no
 Level-specific guidance for portrayal in connection with this issue.
 
@@ -853,8 +850,7 @@ Level-specific guidance for portrayal in connection with this issue.
 ==== Interacting gridded information
 
 There is no Level-specific guidance for portrayal in connection with
-this issue. Common guidance is provided in clause 10.11.1 of the "S-98
-- Main" document.
+this issue. Common guidance is provided in <<S98,clause="10.11.1">>.
 
 === Pick Reports
 
@@ -950,7 +946,7 @@ Included product list from S100_IC_PredefinedCombination.includedProduct
 == Normative Implementation Guidance
 
 There is no level-specific normative implementation guidance in this
-Edition of S-98. See clause 17 of the "S-98 - Main" document for implementation
+Edition of S-98. See <<S98,clause=17>> for implementation
 guidance that applies to all Levels.
 
 [[sec_B-9]]
@@ -963,4 +959,28 @@ Level 2 does not define Feature Catalogues.
 
 Level 2 does not define Portrayal Catalogues.
 
+[bibliography]
+== Bibliography
+
+* [[[S98,dropid(repo:(current-metanorma-collection/IHO S-98))]]],
+span:title[S-98 -- S-100 ECDIS and Interoperability Specification],
+span:edition[2.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartA,dropid(repo:(current-metanorma-collection/IHO S-98 Part A))]]],
+span:title[S-98 -- Part A: Level 1 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartC,dropid(repo:(current-metanorma-collection/IHO S-98 Part C))]]],
+span:title[S-98 -- Part C: Level 3 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartD,dropid(repo:(current-metanorma-collection/IHO S-98 Part D))]]],
+span:title[S-98 -- Part D: Level 4 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[IHO_S_100,IHO S-100]]]
 

--- a/sources/2.0.0/part-b/document.adoc
+++ b/sources/2.0.0/part-b/document.adoc
@@ -1,7 +1,10 @@
 = Data Product Interoperability in S-100 Navigation Systems - Part B: Level 2 Interoperability
 :series: S
 :docnumber: 98
-:doctype: standard
+:partnumber: B
+:title: Data Product Interoperability in S-100 Navigation Systems
+:title-part: Level 2 Interoperability
+:doctype: specification
 :edition: 1.0.0
 :language: en
 :published-date: 2022-05-01

--- a/sources/2.0.0/part-c/document.adoc
+++ b/sources/2.0.0/part-c/document.adoc
@@ -151,8 +151,7 @@ all S-98 Interoperability Catalogues and S-98 Exchange Sets;
 model and Catalogue encoding that are specific to Level 3 interoperability.
 
 The hypothetical processing model for implementations is described
-in general terms in the "S-98 - Main" document and elaborated in clause
-C-C-7 of this Part.
+in general terms in <<S98>> and elaborated in <<sec_C-7>>.
 
 Level 3 interoperability includes the following capabilities:
 
@@ -184,28 +183,29 @@ on these options.
 [[sec_C-1.1]]
 === How to read this Part
 
-Clause C-2 of this Part contains scope identification information
+<<sec_C-2>> of this Part contains scope identification information
 corresponding to the contents of this Part, which applies specifically
 to Interoperability Catalogues designated as Level 3.
 
-For Clauses C-3-C-10, the content of the clause or sub-clause extends
+For <<sec_C-3;to!sec_C-10>>, the content of the clause or sub-clause extends
 or elaborates on the content under the same or similar clause heading
-or sub-heading in the S-98 - Main document.
+or sub-heading in <<S98>>.
 
-The numbering of Clauses C-3-C-10 may differ from that of corresponding
-clauses in S-98 - Main, because for some there is no additional Level-specific
-information needed. If a clause or sub-clause in S-98 - Main has no
+The numbering of <<sec_C-3;to!sec_C-10>> may differ from that of corresponding
+clauses in <<S98>>, because for some there is no additional Level-specific
+information needed. If a clause or sub-clause in <<S98>> has no
 corresponding clause or sub-clause in this Part, there is no level-specific
 information on that topic.
 
-Part C includes Part A and Part B content (pertaining to Levels 1
-and 2), adapted as necessary for Level 3. Reference to Parts A and
-B should therefore not be needed.
+Part C includes <<PartA>> and <<PartB>> content (pertaining to Levels 1
+and 2), adapted as necessary for Level 3. Reference to <<PartA>> and
+<<PartB>> should therefore not be needed.
 
+[[sec_C-2]]
 == Specification Scope for Part C
 
 S-98 Part C describes the portions of S-98 which correspond to the
-following scope defined in S-98 - Main (clause 2):
+following scope defined in <<S98,clause=2>>):
 
 *Scope Identification:* S98L3
 
@@ -219,8 +219,10 @@ type selectivity; interleaving
 *Extent*: EX_Extent.description = "worldwide";
 EX_GeographicBoundingBox = [-180, +180, -90, +90]
 
+[[sec_C-3]]
 == Data Content and Structure
 
+[[sec_C-3.1]]
 === Application Schema
 
 [[sec_C-3.1.1]]
@@ -228,7 +230,7 @@ EX_GeographicBoundingBox = [-180, +180, -90, +90]
 
 The Application Schema for Interoperability Level 3 is depicted in
 <<fig_C-3.1>> below. This Application Schema is a subset of the full
-Application Schema in S-100 Part 16. It consists of the following
+Application Schema in <<IHO_S_100,part=16>>. It consists of the following
 components:
 
 . Catalogue header information.
@@ -290,7 +292,7 @@ is done by evaluating a filter expression (type **FeatureSelector**,
 a string expression conforming to the specified [TBD] format) with
 the feature instance as the input parameter. A *FeatureSelector* is
 a more expressive form of the attribute-value combination filter described
-in clause 4.3 of the "S-98 - Main" document that can include spatial
+in <<S98,clause="4.3">> that can include spatial
 operations and more complex expressions on thematic attributes.
 
 NOTE: If a scripting language for selection is developed it will belong
@@ -376,8 +378,8 @@ Hybrid Feature and Portrayal Catalogues are physically separate files
 from the main Interoperability Catalogue, but the main Catalogue links
 to them by encoding the names of the hybrid Catalogue files which
 are used by the feature creation rules defined in it. The hybrid Feature
-and Portrayal Catalogues conform to the structures required by S-100
-Parts 5 and 9 respectively.
+and Portrayal Catalogues conform to the structures required by
+<<IHO_S_100,part=5>> and <<IHO_S_100,part=9>> respectively.
 
 [[sec_C-3.1.7]]
 ==== Progression of interoperability levels
@@ -405,7 +407,7 @@ image::figure-c-3-2.png["",612,332]
 
 The following clauses summarize the conceptual elements used in Level
 3 Interoperability Catalogues. Details about these conceptual types
-are provided in S-100 Part 16.
+are provided in <<IHO_S_100,part=16>>.
 
 [[sec_C-3.2.1.1]]
 ===== Display plane (S100_IC_DisplayPlane)
@@ -453,7 +455,7 @@ with drawing instructions instead of feature objects. The
 *S100_IC_DrawingInstruction* element in Interoperability Catalogues
 is similar in operation to the layering and priority aspects of the
 *DrawingInstruction* element in Portrayal Catalogues
-(see S-100 Part 9 - Portrayal). Where there is a conflict with a Portrayal
+(see <<IHO_S_100,part=9>>). Where there is a conflict with a Portrayal
 Catalogue drawing instruction, the drawing instruction in the Interoperability
 Catalogue supersedes the drawing instruction in the Portrayal Catalogue.
 
@@ -533,7 +535,7 @@ properties of one feature to properties of another feature.
 ==== Use of S-100 types
 
 The S-100 types used by S-98 Level 3 interoperability catalogues are
-described in the S-98 - Main component of this Specification. For
+described in <<S98>> component of this Specification. For
 Level 3 interoperability catalogues, the following additional information
 applies.
 
@@ -544,17 +546,17 @@ elements. This is the same as the Level 1 and 2 functionality for
 these elements.
 * Interoperability Catalogues of Level 3 are allowed to use feature
 and information associations in feature selector expressions encoded
-in the _primarySelector_ and _secondarySelector_ attributes of *S100__IC_DerivedFeature* or in *S100_SimpleRule* or *S100_ThematicRule* elements.
+in the _primarySelector_ and _secondarySelector_ attributes of *S100_IC_DerivedFeature* or in *S100_SimpleRule* or *S100_ThematicRule* elements.
 
 === UML model documentation
 
-The UML model documentation is provided in S-100 Part 16. This clause
+The UML model documentation is provided in <<IHO_S_100,part=16>>. This clause
 documents details specific to the use of the UML model for the interoperability
 Level described in this Part of S-98.
 
 Only the model elements used in this Level (and included in the Level's
 Application Schema) are listed. The constraints and considerations
-listed in the UML documentation tables in S-100 Part 16 apply. Any
+listed in the UML documentation tables in <<IHO_S_100,part=16>> apply. Any
 S-98 general or Level-specific considerations are described under
 the element name in the list below.
 
@@ -568,8 +570,8 @@ allowed for Level 3 Interoperability Catalogues are 1, 2, and 3.
 . *S100_IC_DrawingInstruction*:
 +
 --
-NOTE: for implementers: Even if the Presentation Schema in S-100 Part
-9 is used, implementers may need to provide specific code to validate
+NOTE: for implementers: Even if the Presentation Schema in <<IHO_S_100,part=9>>
+is used, implementers may need to provide specific code to validate
 the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
@@ -622,7 +624,7 @@ MRN: urn:mrn:iho:prod:s98:1:0:0:products.
 +
 --
 For all Interoperability Levels, the following subset of the standard
-values listed in S-100 Part 16 are permitted to be used in S-98 Interoperability
+values listed in <<IHO_S_100,part=16>> are permitted to be used in S-98 Interoperability
 Catalogues:
 
 [[table_C-.3.1]]
@@ -641,7 +643,7 @@ Catalogues:
 | master | Prepared according to requirements specified by the vessel's master | 8
 |===
 
-Extra values ("other: ...") as defined in S-100 Part 3, clause 3-6.7
+Extra values ("other: ...") as defined in <<IHO_S_100,clause="3-6.7">>
 are also permitted.
 --
 
@@ -721,8 +723,7 @@ or notes.
 [[sec_C-4.1]]
 === Quality of displayed data
 
-There are no Level-specific extensions to clause 6.1 of the
-"S98 - Main" document.
+There are no Level-specific extensions to <<S98,clause="6.1">>.
 
 <<sec_C-5.11>> provides guidance for maintaining data quality for
 Level-specific rules and operations.
@@ -730,19 +731,19 @@ Level-specific rules and operations.
 [[sec_C-4.2]]
 === Quality of Interoperability Catalogues
 
-The quality measures recommended in S-97 (Part C) which are applicable
+The quality measures recommended in <<S97,part=C>> which are applicable
 to Level 3 S-98 Interoperability Catalogues are those listed in
-Table 6-1 of the "S-98 - Main" document plus those listed in
+<<S98,table="6-1">> plus those listed in
 <<table_C-4.1>> below.
 
 [[table_C-4.1]]
 .Quality elements for Level 3 S-98 Interoperability Catalogues
 [cols="a,a,a,a,a,a",options="header"]
 |===
-h| No. h| Data quality element and sub element h| Definition h| DQ measure / description h| Evaluation scope footnote:[For the IC evaluation scope, a "dataset" is an entire Interoperability Catalogue file, an "element" is an Interoperability Catalogue component corresponding to one of the classes in the model depicted in S-100 Part 16, Figure 16-3.] for IC h| Evaluation scope for resultant footnote:["Resultant" means the result of applying interoperability operations to covered data. "Resultant feature" means the apparent feature as it appears on the display after application of interoperability. "Resultant dataset" means the collection of resultant features. A "modified resultant feature" is the feature or drawing instruction resulting from the application of an operation or rule which affects spatial or thematic attributes or their values, including combining or suppressing attributes or generating an instance of a feature defined in the HYBRID Feature Catalogue in Level 3 or 4. A "superseding feature" is a feature which suppresses a feature (instance or type) from another dataset, or whose priority is increased by an interoperability rule or operation (which would make it visible in preference to a feature which would otherwise overlie it). A "superseded feature" is one that is suppressed or overlaid by a superseding feature.] features
+h| No. h| Data quality element and sub element h| Definition h| DQ measure / description h| Evaluation scope footnote:[For the IC evaluation scope, a "dataset" is an entire Interoperability Catalogue file, an "element" is an Interoperability Catalogue component corresponding to one of the classes in the model depicted in <<IHO_S_100,figure="16-3">>.] for IC h| Evaluation scope for resultant footnote:["Resultant" means the result of applying interoperability operations to covered data. "Resultant feature" means the apparent feature as it appears on the display after application of interoperability. "Resultant dataset" means the collection of resultant features. A "modified resultant feature" is the feature or drawing instruction resulting from the application of an operation or rule which affects spatial or thematic attributes or their values, including combining or suppressing attributes or generating an instance of a feature defined in the HYBRID Feature Catalogue in Level 3 or 4. A "superseding feature" is a feature which suppresses a feature (instance or type) from another dataset, or whose priority is increased by an interoperability rule or operation (which would make it visible in preference to a feature which would otherwise overlie it). A "superseded feature" is one that is suppressed or overlaid by a superseding feature.] features
 
 | C1 | Completeness / Omission | Data absent from the dataset, as described by the scope. | numberOfMissingItems / This data quality measure is an indicator that shows that a specific item is missing in the data. | Hybrid FC / PC | Features produced by hybridization rules.
-| C2 | Logical Consistency / Domain Consistency | Adherence of the values to the value domains. | numberOfNonconformantItems / This data quality measure is a count of all items in the dataset that are not in conformance with their value domain. | (See S-98 - Main) | Features produced by hybridization rules.
+| C2 | Logical Consistency / Domain Consistency | Adherence of the values to the value domains. | numberOfNonconformantItems / This data quality measure is a count of all items in the dataset that are not in conformance with their value domain. | (See <<S98>>) | Features produced by hybridization rules.
 | C3 | Thematic Accuracy / ThematicClassificationCorrectness | Comparison
 of the classes assigned to features or their attributes to a universe
 of discourse. | miscalculationRate / This data quality measure indicates
@@ -760,7 +761,7 @@ then the ratio is 1/100 and the reported rate = 0.01. | Hybrid FC
 [[sec_C-4.2.1]]
 ==== Test methods
 
-The provisions of Clause 6.2.1 of the "S-98 - Main" document apply.
+The provisions of <<S98,clause="6.2.1">> apply.
 
 The Level-specific tests in <<table_C-4.1>> should be evaluated only with
 features produced by hybridization rules.
@@ -775,7 +776,7 @@ and values are consistent.
 [[sec_C-4.2.2]]
 ==== Data quality testing
 
-The provisions of clause 6.2.2 of the "S-98 - Main" document apply.
+The provisions of <<S98,clause="6.2.2">> apply.
 Evaluation methods for quality elements C1-C3 in <<table_C-4.1>> should
 include either a complete static analysis of hybridization rules compared
 to Feature and Portrayal Catalogues (either with or without automated
@@ -785,8 +786,9 @@ support) or full test case coverage.
 
 The guidelines in this clause supplement and extend guidance common
 to all Levels on making Product Specifications interoperable, which
-is given in clause 8 of the "S-98 - Main" document.
+is given in <<S98,clause=8>>.
 
+[[sec_C-5.1]]
 === Duplicated features
 
 There is no Level-specific guidance for determining duplicated features.
@@ -816,9 +818,9 @@ added in Level 3.
 [[sec_C-5.1.1]]
 ==== Duplicated features same model
 
-See the guidance in clause 8.1.1 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.1">>, and
 keep in mind the differences between Level 1, 2, and 3 interoperability
-solutions described earlier in Clause C-5.1 of this Part.
+solutions described earlier in <<sec_C-5.1>>.
 
 *S100_IC_SuppressedFeatureLayer* elements only have feature code and
 product as attributes for suppression, this means that all instances
@@ -849,17 +851,17 @@ be used.
 [[sec_C-5.1.2]]
 ==== Duplicated features, different models
 
-See the guidance in clause 8.1.2 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.2">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
-solutions described in Clause C-5.1 of this Part. There is no other
+solutions described in <<sec_C-5.1>>. There is no other
 Level-specific guidance for this scenario.
 
 [[sec_C-5.1.3]]
 ==== Duplicate feature domains
 
-See the guidance in clause 8.1.3 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.3">>, and
 keep in mind the differences between Levels 1, 2, and 3 interoperability
-solutions described in clause C-5.1 of this Part. There is no other
+solutions described in <<sec_C-5.1>>. There is no other
 Level-specific guidance for this scenario.
 
 === Geometry
@@ -867,7 +869,7 @@ Level-specific guidance for this scenario.
 [[sec_C-5.2.1]]
 ==== Combined geometry
 
-See clause 8.2.1 of the "S-98 - Main" document for guidance for developers
+See <<S98,clause="8.2.1">> for guidance for developers
 of Product Specifications that may result in hybrid features when
 interacting with specific other products.
 
@@ -881,18 +883,18 @@ Interoperability Specification.
 ==== Spatial discrepancy, unrelated to scaled or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.2">>.
 
 [[sec_C-5.2.3]]
 ==== Spatial discrepancies, related to scale or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.3 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.3">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 === Skin-of-the-earth feature operations
 
@@ -915,7 +917,7 @@ or simple rule (additional functionality in Level 3).
 * Merging of features from different products creating hybrid features
 (additional functionality in Level 3).
 
-See clause C-6.9 for portrayal considerations.
+See <<sec_C-6.9>> for portrayal considerations.
 
 [[sec_C-5.4.2]]
 ==== Skin-of-the earth feature adjusting
@@ -928,7 +930,7 @@ may be adjusted by combining bathymetry and/or water level information
 with ENC data.
 
 Adjustment of the geometry of skin-of-the-earth features is possible
-only in Level 4 (Part D).
+only in Level 4 (<<PartD>>).
 
 [[sec_C-5.5]]
 === Blended feature concepts
@@ -936,8 +938,8 @@ only in Level 4 (Part D).
 Blended feature concepts or blended portrayals can be produced by
 using transparency between related features; or creating a temporary
 blended feature; or blended portrayal (rule and/or symbol) of specific
-combinations of features from different products. See clause 10 in
-the "S-98 - Main" document for portrayal considerations and an example
+combinations of features from different products. See <<S98,clause=10>>
+for portrayal considerations and an example
 of a use case.
 
 Blended features or portrayal will typically be created by using
@@ -996,19 +998,19 @@ gives the order in which the layers are drawn.
 === New datasets
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.7">>.
 
 [[sec_C-5.8]]
 === Dataset scales, loading, and unloading
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.8">>.
 
 [[sec_C-5.9]]
 === Metadata
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.9 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.9">>.
 
 [[sec_C-5.10]]
 === Meta-features
@@ -1017,12 +1019,12 @@ Any spatial operations on meta-features require an Interoperability
 Catalogue to implement at least Level 4.
 
 There is no other Level-specific guidance for meta-features. Common
-guidance is provided in clause 8.10 of the "S-98 - Main" document.
+guidance is provided in <<S98,clause="8.10">>.
 
 [[sec_C-5.11]]
 === Quality considerations
 
-The guidance in clause 8.11 of the "S-98 - Main" document applies.
+The guidance in <<S98,clause="8.11">> applies.
 
 Developers of Interoperability Catalogues should note that the caution
 about not replacing products of higher data quality with products
@@ -1046,49 +1048,50 @@ are external to the Interoperability Catalogue; in such cases the
 Interoperability Catalogue should continue to function in presence
 of products not defined in the Catalogue. Data products that are outside
 of the interoperability scope must be treated in Interoperability
-Level 0 (see clause 9.6 in the "S-98 - Main" document).
+Level 0 (see <<S98,clause="9.6">>).
 
 === Display of significant features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.1 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.1">>.
 
 === Display of significant features - switching to original
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.2">>.
 
 === Portrayal distinguishability - colour set-asides
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.3 of the "S-98 - Main" document. See also
-S-100 Part 16 for specific guidance on colour set-asides.
+is provided in <<S98,clause="10.3">>. See also
+<<IHO_S_100,part=16>> for specific guidance on colour set-asides.
 
 === Day/night/dusk modes
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.4 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.4">>.
 
 === Impacts on viewing groups
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.5 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.5">>.
 
 === Impacts on Portrayal Catalogues
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.6 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.6">>.
 
 === Meta-features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.7">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
+[[sec_C-6.9]]
 === Skin-of-the-earth operations and portrayal
 
 [[sec_C-6.9.1]]
@@ -1143,11 +1146,11 @@ as "HYBRID", the Hybrid Portrayal Catalogue must be used.
 === Blended portrayals
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.10 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.10">>.
 
 === Hierarchy of data
 
-As noted in clause 11.11 of the "S-98 - Main" document, hierarchy
+As noted in <<S98,clause="11.11">>, hierarchy
 of data can be controlled by predefined combinations (Level 2 and
 higher). Level 1 Catalogues offer only a very limited means of controlling
 hierarchy by means of display plane ordering. There is no Level-specific
@@ -1157,8 +1160,7 @@ guidance for portrayal in connection with this issue.
 ==== Interacting gridded information
 
 There is no level-specific guidance for portrayal in connection with
-this issue. Common guidance is provided in clause 10.11.1 of the
-"S-98 - Main" document.
+this issue. Common guidance is provided in <<S98,clause="10.11.1">>.
 
 === Pick reports
 
@@ -1275,7 +1277,7 @@ a| Level 1: NoneLevels 2, 3: User-selected predefined combination +
 == Normative Implementation Guidance
 
 There is no Level-specific normative implementation guidance in this
-Edition of S-98. See clause 17 of the "S-98 - Main" document for implementation
+Edition of S-98. See <<S98,clause=17>> for implementation
 guidance that applies to all Levels.
 
 == Feature Catalogue
@@ -1286,6 +1288,7 @@ Catalogue developers if the Interoperability Catalogue contains hybridization
 rules which generate feature types that do not conform to the Feature
 Catalogue for one of the input data products.
 
+[[sec_C-10]]
 == Portrayal Catalogue
 
 Level 3 Interoperability Catalogues use a conditionally mandatory
@@ -1293,3 +1296,30 @@ S-98 hybrid Portrayal Catalogue, which must be defined by Interoperability
 Catalogue developers if the Interoperability Catalogue contains hybridization
 rules which generate feature types that do not conform to the Feature
 Catalogue for one of the input data products.
+
+[bibliography]
+== Bibliography
+
+* [[[S98,dropid(repo:(current-metanorma-collection/IHO S-98))]]],
+span:title[S-98 -- S-100 ECDIS and Interoperability Specification],
+span:edition[2.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartA,dropid(repo:(current-metanorma-collection/IHO S-98 Part A))]]],
+span:title[S-98 -- Part A: Level 1 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartB,dropid(repo:(current-metanorma-collection/IHO S-98 Part B))]]],
+span:title[S-98 -- Part B: Level 2 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartD,dropid(repo:(current-metanorma-collection/IHO S-98 Part D))]]],
+span:title[S-98 -- Part D: Level 4 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[IHO_S_100,IHO S-100]]]
+
+* [[[S97,IHO S-97]]]

--- a/sources/2.0.0/part-c/document.adoc
+++ b/sources/2.0.0/part-c/document.adoc
@@ -19,34 +19,121 @@
 :imagesdir: images
 
 [.preface]
-== Document History
+== metanorma-extension
 
+[.boilerplate]
+--
 Changes to this Specification are coordinated by the IHO S-100 Working
 Group. New editions will be made available via the IHO web site. Maintenance
 of the Specification shall conform to IHO Resolution 2/2007 (as amended).
+--
 
-[cols="14,15,14,57",options="unnumbered"]
-|===
-h| Version Number h| Date h| Approved By h| Purpose
+=== document history
 
-| 0.1 | 31 Jul 2017 | EM, RM | First draft.
-| 0.2 | 12 Dec 2017 | RM, EM | Changes from interoperability workshop
-and TSM5.
-| 0.3 | 08 Jul 2018 | EM, RM | Edits from March 2018 review commentsUpdates
-for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3.
-Removed metadata items not used by S-98 from the metadata documentation
-tables.
-| 1.0.0 RC1 | 13 Mar 2019 | RM | Applied S-100 WG4 decisions; updated
-metadata to conform to final version of S-100 Edition 4.0.0.
-| 1.0.0 (Draft) | 21 Mar 2019 | JW | Editorial updates for HSSC.
-| 0.4 | Jan 2020 | RM | Revised after TSM7 decision to separate interoperability
-into an abstract specification (new S-100 Part) and implementation
-specification (S-98).
-| 1.0.0 | May 2022 | S-100WG | Submission to HSSC14 for approval.
-| 1.0.0 | May 2022 | HSSC | Initial published version for evaluation
-and testing.
-
-|===
+[source,yaml]
+----
+- date:
+  - type: updated
+    value: 2017-07-31
+  edition: "0.1"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: First draft
+- date:
+  - type: updated
+    value: 2017-12-12
+  edition: "0.2"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  amend:
+    - description: Changes from interoperability workshop and TSM5.
+- date:
+  - type: updated
+    value: 2018-07-08
+  edition: "0.3"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Edits from March 2018 review comments
+    - description: Updates for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items not used by S-98 from the metadata documentation tables.
+- date:
+  - type: updated
+    value: 2019-03-13
+  edition: "1.0.0 RC1"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Applied S-100 WG4 decisions; updated metadata to conform to final version of S-100 Edition 4.0.0.
+- date:
+  - type: updated
+    value: 2019-03-21
+  edition: "1.0.0. (Draft)"
+  contributor:
+  - person:
+      name:
+        completename: JW
+        abbreviation: JW
+  amend:
+    - description: Editorial updates for HSSC.
+- date:
+  - type: updated
+    value: 2020-01
+  edition: "0.4"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Revised after TSM7 decision to separate interoperability into an abstract specification (new S-100 Part) and implementation specification (S-98).
+- date:
+  - type: updated
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: S-100 Working Group
+      abbreviation: S-100WG
+  amend:
+    - description: Submission to HSSC14 for approval.
+- date:
+  - type: published
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: IHO Hydrographic Services and Standards Committee
+      abbreviation: HSSC
+  amend:
+    - description: Initial published version for evaluation and testing.
+----
 
 [[sec_C-1]]
 == Introduction

--- a/sources/2.0.0/part-c/document.adoc
+++ b/sources/2.0.0/part-c/document.adoc
@@ -1,7 +1,10 @@
 = Data Product Interoperability in S-100 Navigation Systems - Part C: Level 3 Interoperability
 :series: S
 :docnumber: 98
-:doctype: standard
+:partnumber: C
+:title: Data Product Interoperability in S-100 Navigation Systems
+:title-part: Level 3 Interoperability
+:doctype: specification
 :edition: 1.0.0
 :language: en
 :published-date: 2022-05-01

--- a/sources/2.0.0/part-c/document.adoc
+++ b/sources/2.0.0/part-c/document.adoc
@@ -574,7 +574,7 @@ the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
 or interpretable code or rules, etc, in a non-XML syntax. It may be
-enclosed in a <![CDATA[…]]> section so that XML validators treat it
+enclosed in a <![CDATA[...]]> section so that XML validators treat it
 as character data instead of XML.
 --
 

--- a/sources/2.0.0/part-d/document.adoc
+++ b/sources/2.0.0/part-d/document.adoc
@@ -635,7 +635,7 @@ the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
 or interpretable code or rules, etc, in a non-XML syntax. It may be
-enclosed in a `<![CDATA[…]]>` section so that XML validators treat it
+enclosed in a `<![CDATA[...]]>` section so that XML validators treat it
 as character data instead of XML.
 --
 

--- a/sources/2.0.0/part-d/document.adoc
+++ b/sources/2.0.0/part-d/document.adoc
@@ -19,34 +19,121 @@
 :imagesdir: images
 
 [.preface]
-== Document History
+== metanorma-extension
 
+[.boilerplate]
+--
 Changes to this Specification are coordinated by the IHO S-100 Working
 Group. New editions will be made available via the IHO web site. Maintenance
 of the Specification shall conform to IHO Resolution 2/2007 (as amended).
+--
 
-[cols="14,15,14,57",options="unnumbered"]
-|===
-h| Version Number h| Date h| Approved By h| Purpose
+=== document history
 
-| 0.1 | 31 Jul 2017 | EM, RM | First draft.
-| 0.2 | 12 Dec 2017 | RM, EM | Changes from interoperability workshop
-and TSM5.
-| 0.3 | 08 Jul 2018 | EM, RM | Edits from March 2018 review commentsUpdates
-for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3.
-Removed metadata items not used by S-98 from the metadata documentation
-tables.
-| 1.0.0 RC1 | 13 Mar 2019 | RM | Applied S-100 WG4 decisions; updated
-metadata to conform to final version of S-100 Edition 4.0.0.
-| 1.0.0 (Draft) | 21 Mar 2019 | JW | Editorial updates for HSSC.
-| 0.4 | Jan 2020 | RM | Revised after TSM7 decision to separate interoperability
-into an abstract specification (new S-100 Part) and implementation
-specification (S-98).
-| 1.0.0 | May 2022 | S-100WG | Submission to HSSC14 for approval.
-| 1.0.0 | May 2022 | HSSC | Initial published version for evaluation
-and testing.
-
-|===
+[source,yaml]
+----
+- date:
+  - type: updated
+    value: 2017-07-31
+  edition: "0.1"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: First draft
+- date:
+  - type: updated
+    value: 2017-12-12
+  edition: "0.2"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  amend:
+    - description: Changes from interoperability workshop and TSM5.
+- date:
+  - type: updated
+    value: 2018-07-08
+  edition: "0.3"
+  contributor:
+  - person:
+      name:
+        completename: EM
+        abbreviation: EM
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Edits from March 2018 review comments
+    - description: Updates for conformance to S-100 Edition 4.0.0, ISO 19115-1, and 19115-3. Removed metadata items not used by S-98 from the metadata documentation tables.
+- date:
+  - type: updated
+    value: 2019-03-13
+  edition: "1.0.0 RC1"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Applied S-100 WG4 decisions; updated metadata to conform to final version of S-100 Edition 4.0.0.
+- date:
+  - type: updated
+    value: 2019-03-21
+  edition: "1.0.0. (Draft)"
+  contributor:
+  - person:
+      name:
+        completename: JW
+        abbreviation: JW
+  amend:
+    - description: Editorial updates for HSSC.
+- date:
+  - type: updated
+    value: 2020-01
+  edition: "0.4"
+  contributor:
+  - person:
+      name:
+        completename: RM
+        abbreviation: RM
+  amend:
+    - description: Revised after TSM7 decision to separate interoperability into an abstract specification (new S-100 Part) and implementation specification (S-98).
+- date:
+  - type: updated
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: S-100 Working Group
+      abbreviation: S-100WG
+  amend:
+    - description: Submission to HSSC14 for approval.
+- date:
+  - type: published
+    value: 2022-05
+  edition: "1.0.0"
+  contributor:
+  - organization:
+      name: International Hydrographic Organization
+      subdivision: IHO Hydrographic Services and Standards Committee
+      abbreviation: HSSC
+  amend:
+    - description: Initial published version for evaluation and testing.
+----
 
 [[sec_D-1]]
 == Introduction

--- a/sources/2.0.0/part-d/document.adoc
+++ b/sources/2.0.0/part-d/document.adoc
@@ -151,7 +151,7 @@ all S-98 Interoperability Catalogues and S-98 Exchange Sets;
 model and Catalogue encoding that are specific to Level 4 interoperability.
 
 The hypothetical processing model for implementations is described
-in general terms in the "S-98 - Main" document and elaborated in <<sec_D-7>>
+in general terms in <<S98>> and elaborated in <<sec_D-7>>
 of this Part.
 
 Level 4 interoperability includes the following capabilities:
@@ -193,23 +193,23 @@ to Interoperability Catalogues designated as Level 4.
 
 For <<sec_D-3;to!sec_D-10>>, the content of the clause or sub-clause
 extends or elaborates on the content under the same or similar clause
-head or sub-head in the S-98 - Main document.
+head or sub-head in <<S98>>.
 
 The numbering of <<sec_D-3;to!sec_D-10>> may differ from that of corresponding
-clauses in S-98 - Main, because for some there is no additional Level-specific
-information needed. If a clause or sub-clause in S-98 - Main has no
+clauses in <<S98>>, because for some there is no additional Level-specific
+information needed. If a clause or sub-clause in <<S98>> has no
 corresponding clause or sub-clause in this Part, there is no Level-specific
 information on that topic.
 
-Part D includes Part A, Part B and Part C content (pertaining to
+Part D includes <<PartA>>, <<PartB>> and <<PartC>> content (pertaining to
 Levels 1, 2 and 3), adapted as necessary for Level 4. Reference to
-Parts A, B and C should therefore not be needed.
+<<PartA>>, <<PartB>> and <<PartC>> should therefore not be needed.
 
 [[sec_D-2]]
 == Specification Scope for Part D
 
 S-98 Part D describes the portions of S-98 which correspond to the
-following scope defined in S-98 - Main (clause 2):
+following scope defined in <<S98,clause=2>>:
 
 *Scope Identification:* S98L4
 
@@ -233,7 +233,7 @@ EX_GeographicBoundingBox = [-180, +180, -90, +90]
 
 The Application Schema for Interoperability Level 4 is depicted in
 <<fig_D-3.1>> below. This Application Schema is a subset of the full
-Application Schema in S-100 Part 16. It consists of the following
+Application Schema in <<IHO_S_100,part=16>>. It consists of the following
 components:
 
 . Catalogue header information.
@@ -312,7 +312,7 @@ is done by evaluating a filter expression (type **FeatureSelector**,
 a string expression conforming to the specified [TBD] format) with
 the feature instance as input parameter. A *FeatureSelector* is a
 more expressive form of the attribute-value combination filter described
-in clause 4.3 of the "S-98 - Main" document that can include spatial
+in <<S98,clause="4.3">> that can include spatial
 operations and more complex expressions on thematic attributes.
 
 NOTE: If a scripting language for selection is developed it will belong
@@ -434,8 +434,8 @@ Hybrid Feature and Portrayal Catalogues are physically separate files
 from the main Interoperability Catalogue, but the main Catalogue links
 to them by encoding the names of the hybrid Catalogue files which
 are used by the feature creation rules defined in it. The hybrid Feature
-and Portrayal Catalogues conform to the structures required by S-100
-Parts 5 and 9 respectively.
+and Portrayal Catalogues conform to the structures required by
+<<IHO_S_100,part=5>> and <<IHO_S_100,part=9>> respectively.
 
 [[sec_D-3.1.7]]
 ==== Progression of interoperability levels
@@ -464,7 +464,7 @@ image::figure-d-3-2.png["",626,279]
 
 The following clauses summarize the conceptual elements used in Level
 4 Interoperability Catalogues. Details about these conceptual types
-are provided in S-100 Part 16.
+are provided in <<IHO_S_100,part=16>>.
 
 [[sec_D-3.2.1.1]]
 ===== Display plane (S100_IC_DisplayPlane)
@@ -511,8 +511,8 @@ role to feature type display information (*S100_IC_FeatureType*) but
 with drawing instructions instead of feature objects. The
 *S100_IC_DrawingInstruction* element in Interoperability Catalogues
 is similar in operation to the layering and priority aspects of the
-*DrawingInstruction* element in Portrayal Catalogues (see S-100 Part
-9 - Portrayal). Where there is a conflict with a Portrayal Catalogue
+*DrawingInstruction* element in Portrayal Catalogues (see <<IHO_S_100,part=9>>).
+Where there is a conflict with a Portrayal Catalogue
 drawing instruction, the drawing instruction in the Interoperability
 Catalogue supersedes the drawing instruction in the Portrayal Catalogue.
 
@@ -592,7 +592,7 @@ properties of one feature to properties of another feature.
 ==== Use of S-100 types
 
 The S-100 types used by S-98 Level 4 interoperability catalogues are
-described in the S-98 - Main component of this Specification. For
+described in <<S98>> component of this Specification. For
 Level 4 interoperability catalogues, the following additional information
 applies.
 
@@ -609,13 +609,13 @@ or *S100_CompleteRule* elements.
 
 === UML model documentation
 
-The UML model documentation is provided in S-100 Part 16. This clause
+The UML model documentation is provided in <<IHO_S_100,part=16>>. This clause
 documents details specific to the use of the UML model for the interoperability
 Level described in this Part of S-98.
 
 Only the model elements used in this Level (and included in the Level's
 Application Schema) are listed. The constraints and considerations
-listed in the UML documentation tables in S-100 Part 16 apply. Any
+listed in the UML documentation tables in <<IHO_S_100,part=16>> apply. Any
 S-98 general or Level-specific considerations are described under
 the element name in the list below.
 
@@ -629,8 +629,8 @@ for Level 4 Interoperability Catalogues are 1, 2, 3, and 4.
 . *S100_IC_DrawingInstruction*:
 +
 --
-NOTE: for implementers: Even if the Presentation Schema in S-100 Part
-9 is used, implementers may need to provide specific code to validate
+NOTE: for implementers: Even if the Presentation Schema in <<IHO_S_100,part=9>>
+is used, implementers may need to provide specific code to validate
 the content of the _substituteSymbolization_ attribute instead of
 depending on normal XML Schema validation. The content of this attribute
 is not prescribed by this Specification and may be a fragment of XML,
@@ -683,7 +683,7 @@ MRN: urn:mrn:iho:prod:s98:1:0:0:products
 +
 --
 For all Interoperability Levels, the following subset of the standard
-values listed in S-100 Part 16 are permitted to be used in S-98 Interoperability
+values listed in <<IHO_S_100,part=16>> are permitted to be used in S-98 Interoperability
 Catalogues:
 
 [[table_D-3.1]]
@@ -710,7 +710,7 @@ charterer, or operator | 6
 |===
 
 
-Extra values ("other: ...") as defined in S-100 part 3, clause 3-6.7
+Extra values ("other: ...") as defined in <<IHO_S_100,clause="3-6.7">>
 are also permitted.
 --
 
@@ -799,8 +799,7 @@ or notes.
 [[sec_D-4.1]]
 === Quality of displayed data
 
-There are no Level-specific extensions to clause 6.1 of the "S98 -
-Main" document.
+There are no Level-specific extensions to <<S98,clause="6.1">>.
 
 <<sec_D-5.11>> provides guidance for maintaining data quality for
 Level-specific rules and operations.
@@ -808,13 +807,13 @@ Level-specific rules and operations.
 [[sec_D-4.2]]
 === Quality of Interoperability Catalogues
 
-The quality measures recommended in S-97 (Part C) which are applicable
-to Level 4 S-98 Interoperability Catalogues are those listed in Table
-6-1 of the "S-98 - Main" document plus those listed in <<table_D-4.1>>
+The quality measures recommended in <<S97,part=C>> which are applicable
+to Level 4 S-98 Interoperability Catalogues are those listed in <<S98,table="6-1">>
+plus those listed in <<table_D-4.1>>
 below.
 
 S-98 also includes the quality measure "Relative Internal Positional
-Accuracy" (S-100 Part 4c, Appendix 4c-C) as a measure of the accuracy
+Accuracy" (IHO_S_100,locality:appendix="4c-C">>) as a measure of the accuracy
 of any spatial operations during interoperability processing which
 may generate spatial primitives for display purposes from input products.
 
@@ -827,7 +826,7 @@ may generate spatial primitives for display purposes from input products.
 | Evaluation scope footnote:[For the IC evaluation scope, a "dataset"
 is an entire Interoperability Catalogue file, an "element" is an
 Interoperability Catalogue component corresponding to one of the classes
-in the model depicted in S-100 Part 16, Figure 16-3.] for IC
+in the model depicted in <<IHO_S_100,figure="16-3">>.] for IC
 | Evaluation scope for resultant
 footnote:["Resultant" means the result of applying interoperability
 operations to covered data. "Resultant feature" means the apparent
@@ -856,7 +855,7 @@ that shows that a specific item is missing in the data.
 | numberOfNonconformantItems / This data quality measure is a count
 of all items in the dataset that are not in conformance with their
 value domain.
-| (See S-98 - Main) | Features produced by hybridization rules.
+| (See <<S98>>) | Features produced by hybridization rules.
 
 | D3 | Thematic Accuracy / ThematicClassificationCorrectness
 | Comparison of the classes assigned to features or their attributes
@@ -1001,7 +1000,7 @@ to a common vertical datum.
 [[sec_D-4.2.1]]
 ==== Test methods
 
-The provisions of Clause 6.2.1 of the "S-98 - Main" document apply.
+The provisions of <<S98,clause="6.2.1">> apply.
 
 The tests in <<table_D-4.1>> should be evaluated only with features
 produced by hybridization rules.
@@ -1016,7 +1015,7 @@ and values are consistent.
 [[sec_D-4.2.2]]
 ==== Data quality testing
 
-The provisions of clause 6.2.2 of the "S-98 - Main" document apply.
+The provisions of <<S98,clause="6.2.2">> apply.
 Evaluation methods for quality elements D1-D3 in <<table_D-4.1>> should
 include either a complete static analysis of hybridization rules compared
 to Feature and Portrayal Catalogues (either with or without automated
@@ -1027,7 +1026,7 @@ elements D4-D16 may use test datasets.
 
 The guidelines in this clause supplement and extend guidance common
 to all levels on making Product Specifications interoperable, which
-is given in clause 8 of the "S-98 - Main" document.
+is given in <<S98,clause=8>>.
 
 [[sec_D-5.1]]
 === Duplicated features
@@ -1060,7 +1059,7 @@ as Level 3.
 ==== Duplicated features same model
 
 Level 4 offers the same interoperability functionality for resolving
-this as Level 3. See the guidance in the "S-98 - Main" component of
+this as Level 3. See the guidance in <<S98>> component of
 this Specification, and keep in mind the differences between Level
 1, 2, and 3 interoperability solutions described earlier in <<sec_D-5.1>>
 of this Part.
@@ -1094,7 +1093,7 @@ be used.
 [[sec_D-5.1.2]]
 ==== Duplicated features, different models
 
-See the guidance in clause 8.1.2 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.2">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
 solutions described in <<sec_D-5.1>> of this Part. There is no other
 Level-specific guidance for this scenario.
@@ -1102,7 +1101,7 @@ Level-specific guidance for this scenario.
 [[sec_D-5.1.3]]
 ==== Duplicate feature domains
 
-See the guidance in clause 8.1.3 of the "S-98 - Main" document, and
+See the guidance in <<S98,clause="8.1.3">>, and
 keep in mind the differences between Level 1 and Level 2 interoperability
 solutions described in <<sec_D-4.1>> of this Part. There is no other
 Level-specific guidance for this scenario.
@@ -1112,7 +1111,7 @@ Level-specific guidance for this scenario.
 [[sec_D-5.2.1]]
 ==== Combined geometry
 
-See clause 8.2.1 of the "S-98 - Main" document for guidance for developers
+See <<S98,clause="8.2.1">> for guidance for developers
 of Product Specifications that may result in hybrid features when
 interacting with specific other products.
 
@@ -1126,18 +1125,18 @@ Interoperability Specification.
 ==== Spatial discrepancy, unrelated to scaled or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.2">>.
 
 [[sec_D-5.2.3]]
 ==== Spatial discrepancies, related to scale or cartographic smoothing
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.2.3 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.2.3">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 === Skin-of-the-earth feature operations
 
@@ -1195,8 +1194,8 @@ due to the shoaling.
 Blended feature concepts or blended portrayals can be produced by
 using transparency between related features; or creating a temporary
 blended feature; or blended portrayal (rule and/or symbol) of specific
-combinations of features from different products. See clause 10 in
-the "S-98 - Main" document for portrayal considerations and an example
+combinations of features from different products. See <<S98,clause=10>>
+for portrayal considerations and an example
 of a use case.
 
 Blended features or portrayal will typically be created by using
@@ -1255,19 +1254,19 @@ gives the order in which the layers are drawn.
 === New datasets
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.7">>.
 
 [[sec_D-5.8]]
 === Dataset scales, loading, and unloading
 
 There is no Llevel-specific guidance for this issue. Common guidance
-is provided in clause 8.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.8">>.
 
 [[sec_D-5.9]]
 === Metadata
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 8.9 of the "S-98 - Main" document.
+is provided in <<S98,clause="8.9">>.
 
 [[sec_D-5.10]]
 === Meta-features
@@ -1276,12 +1275,12 @@ Any spatial operations on meta-features require an Interoperability
 Catalogue to implement at least Level 4.
 
 There is no other Level-specific guidance for meta-features. Common
-guidance is provided in clause 8.10 of the "S-98 - Main" document.
+guidance is provided in <<S98,clause="8.10">>.
 
 [[sec_D-5.11]]
 === Quality considerations
 
-The guidance in clause 8.11 of the "S-98 - Main" document applies.
+The guidance in <<S98,clause="8.11">> applies.
 
 Developers of Interoperability Catalogues should note that the caution
 about not replacing products of higher data quality with products
@@ -1315,48 +1314,48 @@ are external to the Interoperability Catalogue; in such cases the
 Interoperability Catalogue should continue to function in presence
 of products not defined in the Catalogue. Data products that are outside
 of the interoperability scope must be treated in Interoperability
-Level 0 (see clause 9.6 in the "S-98 - Main" document).
+Level 0 (see <<S98,clause="9.6">>).
 
 === Display of significant features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.1 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.1">>.
 
 === Display of significant features - switching to original
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.2 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.2">>.
 
 === Portrayal distinguishability - colour set-asides
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.3 of the "S-98 - Main" document. See also
-S-100 Part 16 for specific guidance on colour set-asides.
+is provided in <<S98,clause="10.3">>. See also
+<<IHO_S_100,part=16>> for specific guidance on colour set-asides.
 
 === Day/night/dusk modes
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.4 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.4">>.
 
 === Impacts on viewing groups
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.5 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.5">>.
 
 === Impacts on Portrayal Catalogues
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.6 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.6">>.
 
 === Meta-features
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.7 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.7">>.
 
 === Display of text
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.8 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.8">>.
 
 [[sec_D-6.9]]
 === Skin-of-the-earth operations and portrayal
@@ -1427,11 +1426,11 @@ in ways that depend on vessel characteristics and icebreaker activity.
 === Blended portrayals
 
 There is no Level-specific guidance for this issue. Common guidance
-is provided in clause 10.10 of the "S-98 - Main" document.
+is provided in <<S98,clause="10.10">>.
 
 === Hierarchy of data
 
-As noted in clause 11.11 of the "S-98 - Main" document, hierarchy
+As noted in <<S98,clause="11.11">>, hierarchy
 of data can be controlled by predefined combinations (Level 2 and
 higher). Level 1 Catalogues offer only a very limited means of controlling
 hierarchy by means of display plane ordering. There is no Level-specific
@@ -1441,8 +1440,7 @@ guidance for portrayal in connection with this issue.
 ==== Interacting gridded information
 
 There is no Level-specific guidance for portrayal in connection with
-this issue. Common guidance is provided in clause 10.11.1 of the
-"S-98 - Main" document.
+this issue. Common guidance is provided in <<S98,clause="10.11.1">>.
 
 === Pick reports
 
@@ -1582,7 +1580,7 @@ functions.
 == Normative Implementation Guidance
 
 There is no Level-specific normative implementation guidance in this
-Edition of S-98. See clause 17 of the "S-98 - Main" document for implementation
+Edition of S-98. See <<S98,clause=17>> for implementation
 guidance that applies to all Levels.
 
 == Feature Catalogue
@@ -1601,3 +1599,31 @@ S-98 hybrid Portrayal Catalogue, which must be defined by Interoperability
 Catalogue developers if the Interoperability Catalogue contains hybridization
 rules which generate feature types which do not conform to the Feature
 Catalogue for one of the input data products.
+
+[bibliography]
+== Bibliography
+
+* [[[S98,dropid(repo:(current-metanorma-collection/IHO S-98))]]],
+span:title[S-98 -- S-100 ECDIS and Interoperability Specification],
+span:edition[2.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartA,dropid(repo:(current-metanorma-collection/IHO S-98 Part A))]]],
+span:title[S-98 -- Part A: Level 1 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartB,dropid(repo:(current-metanorma-collection/IHO S-98 Part B))]]],
+span:title[S-98 -- Part B: Level 2 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[PartC,dropid(repo:(current-metanorma-collection/IHO S-98 Part C))]]],
+span:title[S-98 -- Part C: Level 3 Interoperability],
+span:edition[1.0.0],
+span:organization[International Hydrographic Organization]
+
+* [[[IHO_S_100,IHO S-100]]]
+
+* [[[S97,IHO S-97]]]
+

--- a/sources/2.0.0/part-d/document.adoc
+++ b/sources/2.0.0/part-d/document.adoc
@@ -813,7 +813,7 @@ plus those listed in <<table_D-4.1>>
 below.
 
 S-98 also includes the quality measure "Relative Internal Positional
-Accuracy" (IHO_S_100,locality:appendix="4c-C">>) as a measure of the accuracy
+Accuracy" (<<IHO_S_100,locality:appendix="4c-C">>) as a measure of the accuracy
 of any spatial operations during interoperability processing which
 may generate spatial primitives for display purposes from input products.
 

--- a/sources/2.0.0/part-d/document.adoc
+++ b/sources/2.0.0/part-d/document.adoc
@@ -1,7 +1,10 @@
 = Data Product Interoperability in S-100 Navigation Systems - Part D: Level 4 Interoperability
 :series: S
 :docnumber: 98
-:doctype: standard
+:partnumber: D
+:title: Data Product Interoperability in S-100 Navigation Systems
+:title-part: Level 4 Interoperability
+:doctype: specification
 :edition: 1.0.0
 :language: en
 :published-date: 2022-05-01


### PR DESCRIPTION
This PR merges #3 and fixes markup in it, as well as in the already merged IHO S-98 files to generate a collection properly.

Note:
The original S-98 main document contains cross-references to non-existing sections: "S-98 clauses 12.1.1-12.1.3".